### PR TITLE
Recording feature + bug fixes and efficiency improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## Unreleased
 
-- Add session recording: start→stop capture that writes continuously and saves one MP4 (screen + system audio + mic) when stopped — available from the menu bar and a new hotkey, independent of the instant-replay buffer
+- Add session recording: a start→stop screen recorder that taps the already-encoded capture stream (no re-encode) and writes one continuous MP4, saved when you stop — from the menu bar or a new hotkey, running alongside the instant-replay buffer. Independent "record system audio" and "record microphone" toggles (any combination) that don't affect replay clips; matches every Video-section setting (display, capture mode, resolution/Retina, frame rate, bitrate, codec, quality preset); opens on a keyframe so there's no black lead-in; and finalizes an in-progress recording on quit
+- Fix desaturated saved clips: tag the capture and encoded stream as sRGB / BT.709 (full range) end to end so players apply the right color matrix — corrects both instant-replay clips and session recordings
+- Skip per-frame background work for the extended replay buffer when it's disabled (the default), removing continuous idle task churn from the capture hot path
 - Publish the Mac App Store edition as ReplayCap after App Review rejected "Mac" in the app name (Guideline 5.2.5); the direct/GitHub build keeps the ReplayMac name via a launch-time branding constant shared across both builds
 - Share on-disk metadata and long-buffer names between both editions (`.ReplayCapClipLibrary.json`, `.ReplayCapLongBuffer`), migrating existing `.ReplayMac…` files automatically
 - Notarize the direct-download build: release DMGs are signed with a Developer ID certificate, hardened runtime, and a stapled notarization ticket, so the app opens without Gatekeeper workarounds

--- a/Sources/App/AppDelegate+BufferMonitoring.swift
+++ b/Sources/App/AppDelegate+BufferMonitoring.swift
@@ -89,6 +89,14 @@ extension AppDelegate {
                     continue
                 }
 
+                // A screen recording is unbounded in length, so guard the disk:
+                // stop and finalize before it fills up.
+                if self.isSessionRecordingActive,
+                   let available = self.availableDiskCapacityBytes(),
+                   available < 500 * 1024 * 1024 {
+                    self.stopScreenRecording(reason: .lowDisk)
+                }
+
                 let videoMemory = self.videoRingBuffer.currentMemoryBytes
                 let dualDisplay1Memory = self.dualDisplay1VideoRingBuffer.currentMemoryBytes
                 let dualDisplay2Memory = self.dualDisplay2VideoRingBuffer.currentMemoryBytes

--- a/Sources/App/AppDelegate+CapturePipeline.swift
+++ b/Sources/App/AppDelegate+CapturePipeline.swift
@@ -17,7 +17,8 @@ extension AppDelegate {
     func configurePipelines() {
         videoEncoder.outputHandler = replayCapPrimaryVideoOutputHandler(
             videoRingBuffer: videoRingBuffer,
-            longBufferAppendPump: longBufferAppendPump
+            longBufferAppendPump: longBufferAppendPump,
+            sessionAppendPump: sessionAppendPump
         )
         dualDisplay1VideoEncoder.outputHandler = replayCapDualVideoOutputHandler(dualDisplay1VideoRingBuffer)
         dualDisplay2VideoEncoder.outputHandler = replayCapDualVideoOutputHandler(dualDisplay2VideoRingBuffer)
@@ -26,14 +27,16 @@ extension AppDelegate {
 
         systemAudioEncoder.outputHandler = replayCapSystemAudioOutputHandler(
             systemAudioRingBuffer: systemAudioRingBuffer,
-            longBufferAppendPump: longBufferAppendPump
+            longBufferAppendPump: longBufferAppendPump,
+            sessionAppendPump: sessionAppendPump
         )
         systemAudioCapture.setHandler(replayCapAudioEncodeHandler(systemAudioEncoder))
         perAppAudioCapture.setHandler(replayCapPerAppAudioHandler(systemAudioCapture))
 
         micAudioEncoder.outputHandler = replayCapMicrophoneOutputHandler(
             micAudioRingBuffer: micAudioRingBuffer,
-            longBufferAppendPump: longBufferAppendPump
+            longBufferAppendPump: longBufferAppendPump,
+            sessionAppendPump: sessionAppendPump
         )
         micAudioCapture.setHandler(replayCapAudioEncodeHandler(micAudioEncoder))
     }
@@ -67,9 +70,13 @@ extension AppDelegate {
             micAudioRingBuffer.clear()
             AudioLevelMonitor.shared.reset()
             longBufferAppendPump.reset()
+            sessionAppendPump.reset()
             await configureLongBufferForCurrentSettings()
 
-                let shouldCaptureMic = AppSettings.captureMicrophone
+                // Capture the union of what the replay buffer and an active screen
+                // recording need. Mic is an independent device path (added live);
+                // system audio comes up with the SCK stream here.
+                let shouldCaptureMic = desiredMicEnabled
                 let micPermissionGranted = shouldCaptureMic ? await requestMicrophonePermissionIfNeeded() : false
                 if shouldCaptureMic && !micPermissionGranted {
                     notifyMicPermissionDeniedIfNeeded()
@@ -81,8 +88,11 @@ extension AppDelegate {
                 let fps = AppSettings.frameRate
                 let queueDepth = AppSettings.queueDepth
                 let excludeOwn = AppSettings.excludeOwnAppAudio
-                var captureSystemAudioForSession = AppSettings.captureSystemAudio
-                var usePerAppAudio = captureSystemAudioForSession
+                var captureSystemAudioForSession = desiredSystemAudioForSCK
+                // Per-app audio is a replay-buffer feature: only use it when the
+                // replay buffer wants system audio. A recording that needs system
+                // audio while replay's is off gets the all-apps stream instead.
+                var usePerAppAudio = AppSettings.captureSystemAudio
                     && AppSettings.perAppAudioEnabled
                     && !AppSettings.perAppAudioBundleID.isEmpty
 
@@ -106,7 +116,7 @@ extension AppDelegate {
             if isDual {
                     let dualSaveMode = AppSettings.dualCaptureSaveModeEnum
                     await configureDualVideoHandlers(saveMode: dualSaveMode)
-                    await captureManager.setAudioHandler1(replayCapSystemAudioProcessHandler(systemAudioCapture))
+                    await captureManager.setAudioHandler1(replayCapSystemAudioProcessHandler(systemAudioCapture, sessionAppendPump: sessionAppendPump))
 
                     let captureDisplayID1 = AppSettings.captureDisplayID.isEmpty ? nil : AppSettings.captureDisplayID
                     let captureDisplayID2 = AppSettings.captureDisplayID2.isEmpty ? nil : AppSettings.captureDisplayID2
@@ -272,6 +282,7 @@ extension AppDelegate {
         await captureManager.stop()
         await perAppAudioCapture.stop()
         longBufferAppendPump.reset()
+        sessionAppendPump.reset()
         await longBufferRecorder.stop(deleteSegments: false)
         micAudioCapture.stop()
         videoEncoder.stop()
@@ -293,7 +304,7 @@ extension AppDelegate {
         captureAudio: Bool
     ) async throws {
         await captureManager.setVideoHandler(replayCapVideoEncodeHandler(videoEncoder))
-        await captureManager.setAudioHandler(replayCapSystemAudioProcessHandler(systemAudioCapture))
+        await captureManager.setAudioHandler(replayCapSystemAudioProcessHandler(systemAudioCapture, sessionAppendPump: sessionAppendPump))
 
         let config = try await captureManager.start(
             interactivePermissionPrompt: userInitiated,
@@ -353,30 +364,20 @@ extension AppDelegate {
             captureRecoveryTask = nil
         }
         guard isCaptureRunning else {
-            if isSessionRecording {
-                await stopSessionRecording(userInitiated: false)
-            }
             return
         }
 
+        // A screen recording taps the live encoded stream, so it can't outlive the
+        // pipeline. Finalize it (saving what was captured) before tearing down.
+        await finalizeSessionRecordingIfActive(reason: .pipelineStopped)
+
         monitoringTask?.cancel()
         monitoringTask = nil
-
-        // Finalize session to a real file before tearing capture down. On a
-        // recoverable interruption we discard instead so resume starts clean.
-        if isSessionRecording {
-            if preserveResumeIntent {
-                await discardSessionRecording()
-            } else {
-                await stopSessionRecording(userInitiated: false)
-            }
-        }
 
         await captureManager.stop()
         await perAppAudioCapture.stop()
         longBufferAppendPump.reset()
         await longBufferRecorder.stop(deleteSegments: !preserveResumeIntent)
-        await sessionRecorder.stop(deleteSegments: true)
         micAudioCapture.stop()
         videoEncoder.stop()
         dualDisplay1VideoEncoder.stop()
@@ -387,9 +388,9 @@ extension AppDelegate {
         AudioLevelMonitor.shared.reset()
 
         isCaptureRunning = false
+        captureAutoStartedBySessionRecording = false
         menuBarState.setRecording(false)
         menuBarState.setExtendedBufferRecording(false)
-        menuBarState.setSessionRecording(false)
         menuBarState.setBufferedSeconds(0)
         statusItemController.refreshPresentation()
     }
@@ -398,6 +399,7 @@ extension AppDelegate {
         let separateDualSave = AppSettings.captureMode == CaptureMode.dualSideBySide.rawValue
             && AppSettings.dualCaptureSaveMode == DualCaptureSaveMode.separateFiles.rawValue
         let enabled = AppSettings.longBufferEnabled && !separateDualSave
+        longBufferAppendPump.setEnabled(enabled)
         await longBufferRecorder.configure(
             enabled: enabled,
             maxDurationSeconds: TimeInterval(AppSettings.longBufferDurationSeconds),
@@ -411,21 +413,13 @@ extension AppDelegate {
                 body: "Extended replay is not available while dual display clips are saved as separate files."
             )
         }
-
-        // Session recording uses the primary/composited stream only.
-        if isSessionRecording && separateDualSave {
-            NotificationManager.shared.showOperationalNotification(
-                title: "Session Recording Stopped",
-                body: "Session recording can’t continue while dual display clips are saved as separate files. Saving what was captured…"
-            )
-            await stopSessionRecording(userInitiated: false)
-        }
     }
 
     func toggleCapturePipeline() {
         // A manual start or stop hands recording control back to the user, so
         // the game watcher must no longer treat this session as one it owns.
         recordingAutoStartedByGame = false
+        captureAutoStartedBySessionRecording = false
         if isCaptureRunning {
             Task { await stopCapturePipelineAsync() }
         } else {

--- a/Sources/App/AppDelegate+Hotkeys.swift
+++ b/Sources/App/AppDelegate+Hotkeys.swift
@@ -18,11 +18,11 @@ extension AppDelegate {
         hotkeyManager.onSaveLongBuffer = { [weak self] in
             self?.saveLongBufferFromUI()
         }
-        hotkeyManager.onToggleSessionRecording = { [weak self] in
-            self?.toggleSessionRecording()
-        }
         hotkeyManager.onOpenClipLibrary = { [weak self] in
             self?.openClipLibraryWindow()
+        }
+        hotkeyManager.onToggleScreenRecording = { [weak self] in
+            self?.toggleScreenRecording()
         }
         hotkeyManager.start()
     }

--- a/Sources/App/AppDelegate+PipelineHandlers.swift
+++ b/Sources/App/AppDelegate+PipelineHandlers.swift
@@ -25,9 +25,14 @@ func replayCapSecondaryFrameCompositorHandler(_ frameCompositor: FrameCompositor
     }
 }
 
-func replayCapSystemAudioProcessHandler(_ systemAudioCapture: SystemAudioCapture) -> @Sendable (CMSampleBuffer) -> Void {
+func replayCapSystemAudioProcessHandler(
+    _ systemAudioCapture: SystemAudioCapture,
+    sessionAppendPump: SessionAppendPump
+) -> @Sendable (CMSampleBuffer) -> Void {
     { sampleBuffer in
-        if AppSettings.captureSystemAudio {
+        // Process system audio if either the replay buffer or an active screen
+        // recording wants it. Per-consumer distribution is gated downstream.
+        if AppSettings.captureSystemAudio || sessionAppendPump.systemAudioWanted {
             systemAudioCapture.process(sampleBuffer: sampleBuffer)
         }
     }
@@ -41,11 +46,20 @@ func replayCapPerAppAudioHandler(_ systemAudioCapture: SystemAudioCapture) -> @S
 
 func replayCapPrimaryVideoOutputHandler(
     videoRingBuffer: VideoRingBuffer,
-    longBufferAppendPump: LongBufferAppendPump
+    longBufferAppendPump: LongBufferAppendPump,
+    sessionAppendPump: SessionAppendPump
 ) -> VideoEncoder.OutputHandler {
     { sampleBuffer in
         videoRingBuffer.append(encodedSample: sampleBuffer)
-        longBufferAppendPump.enqueueVideo(LongBufferSample(sampleBuffer))
+        // Wrap the encoded frame once, and only when a consumer actually wants it,
+        // so an idle long buffer / inactive recording adds no per-frame work.
+        let longWants = longBufferAppendPump.isEnabled
+        let sessionWants = sessionAppendPump.isActive
+        if longWants || sessionWants {
+            let sample = LongBufferSample(sampleBuffer)
+            if longWants { longBufferAppendPump.enqueueVideo(sample) }
+            if sessionWants { sessionAppendPump.enqueueVideo(sample) }
+        }
     }
 }
 
@@ -67,20 +81,45 @@ func replayCapAudioEncodeHandler(_ audioEncoder: AudioEncoder) -> @Sendable (CMS
 
 func replayCapSystemAudioOutputHandler(
     systemAudioRingBuffer: AudioRingBuffer,
-    longBufferAppendPump: LongBufferAppendPump
+    longBufferAppendPump: LongBufferAppendPump,
+    sessionAppendPump: SessionAppendPump
 ) -> AudioEncoder.OutputHandler {
     { sampleBuffer in
-        systemAudioRingBuffer.append(sampleBuffer)
-        longBufferAppendPump.enqueueSystemAudio(LongBufferSample(sampleBuffer))
+        // Feed the replay buffer only when the replay buffer itself wants system
+        // audio, so a recording that captures system audio (while replay doesn't)
+        // never leaks into replay clips. The session pump gates on its own toggle.
+        let replayWants = AppSettings.captureSystemAudio
+        if replayWants {
+            systemAudioRingBuffer.append(sampleBuffer)
+        }
+        let longWants = replayWants && longBufferAppendPump.isEnabled
+        let sessionWants = sessionAppendPump.systemAudioWanted
+        if longWants || sessionWants {
+            let sample = LongBufferSample(sampleBuffer)
+            if longWants { longBufferAppendPump.enqueueSystemAudio(sample) }
+            if sessionWants { sessionAppendPump.enqueueSystemAudio(sample) }
+        }
     }
 }
 
 func replayCapMicrophoneOutputHandler(
     micAudioRingBuffer: AudioRingBuffer,
-    longBufferAppendPump: LongBufferAppendPump
+    longBufferAppendPump: LongBufferAppendPump,
+    sessionAppendPump: SessionAppendPump
 ) -> AudioEncoder.OutputHandler {
     { sampleBuffer in
-        micAudioRingBuffer.append(sampleBuffer)
-        longBufferAppendPump.enqueueMicrophone(LongBufferSample(sampleBuffer))
+        // Mic hardware may be running only because the recording wants it; keep it
+        // out of replay clips unless the replay buffer's own mic toggle is on.
+        let replayWants = AppSettings.captureMicrophone
+        if replayWants {
+            micAudioRingBuffer.append(sampleBuffer)
+        }
+        let longWants = replayWants && longBufferAppendPump.isEnabled
+        let sessionWants = sessionAppendPump.microphoneWanted
+        if longWants || sessionWants {
+            let sample = LongBufferSample(sampleBuffer)
+            if longWants { longBufferAppendPump.enqueueMicrophone(sample) }
+            if sessionWants { sessionAppendPump.enqueueMicrophone(sample) }
+        }
     }
 }

--- a/Sources/App/AppDelegate+RuntimeSettings.swift
+++ b/Sources/App/AppDelegate+RuntimeSettings.swift
@@ -155,6 +155,15 @@ extension AppDelegate {
     }
 
     func applyPipelineShapeChanges() async throws {
+        // Restarting the video encoder here yields a new format description that
+        // the recording's fixed-format writer can't accept, so end any active
+        // screen recording first (the user is notified and the clip so far saved).
+        // This is the one reshape path that bypasses stopCapturePipelineAsync.
+        // If that recording owned the pipeline (replay was idle), finalize stops it
+        // rather than leaving it running with no owner — so bail out of the reshape.
+        await finalizeSessionRecordingIfActive(reason: .captureSettingsChanged, mayStopPipeline: true)
+        guard isCaptureRunning else { return }
+
         let codec: Encode.VideoCodec = AppSettings.videoCodec == "hevc" ? .hevc : .h264
         let bitrate = Int(AppSettings.bitrateMbps * 1_000_000)
         let fps = AppSettings.frameRate
@@ -297,7 +306,10 @@ extension AppDelegate {
     }
 
     func applyMicSettingIfNeeded() async {
-        let shouldCaptureMic = AppSettings.captureMicrophone
+        // Union of replay-buffer and active-recording mic needs, so a replay
+        // mic-off toggle doesn't kill a recording that wants the mic (and vice
+        // versa). lastMicEnabled/lastMicDeviceID then track the union state.
+        let shouldCaptureMic = desiredMicEnabled
         let selectedMicDeviceID = AppSettings.microphoneID
         let micSettingsChanged = shouldCaptureMic != lastMicEnabled || selectedMicDeviceID != lastMicDeviceID
         guard micSettingsChanged else { return }

--- a/Sources/App/AppDelegate+Saving.swift
+++ b/Sources/App/AppDelegate+Saving.swift
@@ -217,7 +217,7 @@ extension AppDelegate {
         return app.localizedName
     }
 
-    private func availableDiskCapacityBytes() -> Int64? {
+    func availableDiskCapacityBytes() -> Int64? {
         // Probe the output directory if it exists, otherwise the home directory
         // (same volume), since the output folder is created lazily on first save.
         let outputURL = AppSettings.outputDirectoryURL

--- a/Sources/App/AppDelegate+SessionRecording.swift
+++ b/Sources/App/AppDelegate+SessionRecording.swift
@@ -1,181 +1,293 @@
 import Foundation
+import Encode
+import Feedback
 import Save
 import UI
-import Feedback
+
+/// Why a screen recording stopped — drives whether (and how) the user is told.
+enum SessionRecordingStopReason {
+    /// The user pressed the hotkey / menu item (or the app is quitting).
+    case userToggled
+    /// A capture/encoding setting changed, forcing an encoder restart.
+    case captureSettingsChanged
+    /// Free disk space dropped below the safety margin.
+    case lowDisk
+    /// The underlying capture pipeline stopped (manual replay toggle, sleep/wake,
+    /// interruption).
+    case pipelineStopped
+}
 
 @MainActor
 extension AppDelegate {
-    /// Start→stop session recording: writes continuously until stopped, then
-    /// saves one MP4 (screen + system audio + mic per current capture settings).
-    func toggleSessionRecording() {
-        Task {
-            if isSessionRecording {
-                await stopSessionRecording(userInitiated: true)
+    // MARK: - Capture union
+
+    /// System audio must be captured when either the replay buffer or an active
+    /// recording wants it. Read while (re)starting the pipeline.
+    var desiredSystemAudioForSCK: Bool {
+        AppSettings.captureSystemAudio || (isSessionRecordingActive && sessionWantsSystemAudio)
+    }
+
+    /// Microphone must be captured when either the replay buffer or an active
+    /// recording wants it.
+    var desiredMicEnabled: Bool {
+        AppSettings.captureMicrophone || (isSessionRecordingActive && sessionWantsMicrophone)
+    }
+
+    // MARK: - Serialized start/stop
+
+    /// User-initiated start/stop run one-at-a-time so they can never interleave
+    /// across their `await`s — which otherwise orphans the capture pipeline on a
+    /// rapid start→stop, or double-finalizes on a repeated low-disk stop.
+    private func enqueueSessionOp(_ op: @escaping @MainActor () async -> Void) {
+        let previous = sessionRecordingOpTask
+        sessionRecordingOpTask = Task { @MainActor in
+            _ = await previous?.value
+            await op()
+        }
+    }
+
+    func toggleScreenRecording() {
+        enqueueSessionOp { [weak self] in
+            guard let self else { return }
+            if self.isSessionRecordingActive {
+                await self.performStopScreenRecording(reason: .userToggled)
             } else {
-                await startSessionRecording(userInitiated: true)
+                await self.performStartScreenRecording()
             }
         }
     }
 
-    func startSessionRecording(userInitiated: Bool) async {
-        guard !isSessionRecording, !isSessionFinalizeInProgress else {
-            return
+    func stopScreenRecording(reason: SessionRecordingStopReason) {
+        enqueueSessionOp { [weak self] in
+            guard let self, self.isSessionRecordingActive else { return }
+            await self.performStopScreenRecording(reason: reason)
         }
+    }
 
+    // MARK: - Start
+
+    private func performStartScreenRecording() async {
+        guard !isSessionRecordingActive else { return }
+
+        // The recording taps the primary composite encoder; dual "separate files"
+        // has no single composite stream (like the long buffer), so block it.
         if isSeparateDualSaveMode {
             NotificationManager.shared.showOperationalNotification(
-                title: "Session Recording Unavailable",
-                body: "Session recording is not available while dual display clips are saved as separate files. Switch to a side-by-side save, or use single-display capture."
+                title: "Screen Recording Unavailable",
+                body: "Turn off saving dual displays as separate files to record a single screen recording."
             )
             return
         }
 
-        // Reserve room for at least a few minutes so we don't start into a full disk.
-        if let diskFailure = diskSpaceFailure(lastSeconds: 5 * 60, streamCount: 1) {
-            let message = SavePreflight.notificationMessage(for: diskFailure)
-            NotificationManager.shared.showOperationalNotification(title: message.title, body: message.body)
-            return
-        }
-
-        if !isCaptureRunning {
-            await startCapturePipelineAsync(userInitiated: userInitiated)
-            guard isCaptureRunning else {
-                return
-            }
-        }
-
-        await sessionRecorder.configure(
-            enabled: true,
-            maxDurationSeconds: .infinity,
-            outputDirectory: AppSettings.outputDirectoryURL,
-            storage: .session
-        )
-
-        isSessionRecording = true
-        menuBarState.setSessionRecording(true)
-        statusItemController.refreshPresentation()
-
-        if userInitiated {
+        if let available = availableDiskCapacityBytes(), available < 1_000 * 1024 * 1024 {
             NotificationManager.shared.showOperationalNotification(
-                title: "Session Recording Started",
-                body: "Recording until you stop it. Stop from the menu bar or your session hotkey to save the file."
+                title: "Not Enough Disk Space",
+                body: "Free up at least 1 GB before starting a screen recording."
+            )
+            return
+        }
+
+        let wantsSystemAudio = AppSettings.sessionRecordingSystemAudio
+        let wantsMicrophone = AppSettings.sessionRecordingMicrophone
+
+        // Adding system audio the replay buffer isn't already capturing requires a
+        // one-time capture restart, which resets the replay buffer. Tell the user.
+        if isCaptureRunning, wantsSystemAudio, !AppSettings.captureSystemAudio {
+            NotificationManager.shared.showOperationalNotification(
+                title: "Replay Buffer Reset",
+                body: "Recording system audio restarted capture to add it, which cleared the current replay buffer."
             )
         }
+
+        sessionWantsSystemAudio = wantsSystemAudio
+        sessionWantsMicrophone = wantsMicrophone
+        isSessionRecordingActive = true
+        sessionRecordingStartedAt = Date()
+        sessionAppendPump.configure(recordSystemAudio: wantsSystemAudio, recordMicrophone: wantsMicrophone)
+
+        await sessionRecorder.start(
+            outputDirectory: AppSettings.outputDirectoryURL,
+            recordSystemAudio: wantsSystemAudio,
+            recordMicrophone: wantsMicrophone,
+            baseName: resolvedClipBaseName()
+        )
+        await activateScreenRecordingCapture(wantsSystemAudio: wantsSystemAudio, wantsMicrophone: wantsMicrophone)
     }
 
-    @discardableResult
-    func stopSessionRecording(userInitiated: Bool) async -> URL? {
-        guard isSessionRecording || isSessionFinalizeInProgress else {
-            return nil
-        }
-        guard !isSessionFinalizeInProgress else {
-            return nil
-        }
-
-        isSessionFinalizeInProgress = true
-        isSessionRecording = false
-        menuBarState.setSessionRecording(false)
-        statusItemController.refreshPresentation()
-
-        let durationHint = max(menuBarState.sessionElapsedSeconds, 1)
-        if let diskFailure = diskSpaceFailure(lastSeconds: durationHint, streamCount: 2) {
-            let message = SavePreflight.notificationMessage(for: diskFailure)
-            NotificationManager.shared.showOperationalNotification(title: message.title, body: message.body)
-            await discardSessionRecording()
-            isSessionFinalizeInProgress = false
-            statusItemController.refreshPresentation()
-            return nil
-        }
-
-        if !menuBarState.beginSaving() {
-            // Another save is in flight — wait briefly then try again once.
-            try? await Task.sleep(for: .milliseconds(400))
-            if !menuBarState.beginSaving() {
-                await discardSessionRecording()
-                isSessionFinalizeInProgress = false
+    private func activateScreenRecordingCapture(wantsSystemAudio: Bool, wantsMicrophone: Bool) async {
+        if !isCaptureRunning {
+            captureAutoStartedBySessionRecording = true
+            await startCapturePipelineAsync(userInitiated: false)
+            guard isCaptureRunning else {
                 NotificationManager.shared.showOperationalNotification(
-                    title: "Couldn’t Save Session",
-                    body: "Another save was already in progress. The session recording was discarded."
+                    title: "Screen Recording Failed",
+                    body: "Screen capture could not start, so recording did not begin."
                 )
-                statusItemController.refreshPresentation()
-                return nil
+                await rollBackScreenRecordingStart()
+                return
             }
+        } else if wantsSystemAudio && !AppSettings.captureSystemAudio {
+            // System audio comes from the SCK stream and is fixed at stream
+            // creation, so a one-time restart is needed to add it. The append pump
+            // is still inactive, so this restart does not trip the
+            // stop-on-reconfigure finalize.
+            await restartFullPipeline()
+            guard isCaptureRunning else {
+                await rollBackScreenRecordingStart()
+                return
+            }
+        } else if wantsMicrophone {
+            // Mic is an independent device path — added live, no restart.
+            await applyMicSettingIfNeeded()
+        }
+
+        sessionAppendPump.setActive(true)
+        // Ask the encoder for an immediate keyframe so the recording opens on a
+        // decodable frame (no black lead-in) without waiting for the next natural
+        // keyframe up to ~2s away.
+        videoEncoder.forceNextKeyframe()
+        menuBarState.setSessionRecording(true)
+        statusItemController.refreshPresentation()
+    }
+
+    private func rollBackScreenRecordingStart() async {
+        sessionAppendPump.setActive(false)
+        _ = await sessionRecorder.stop()
+        let ownedPipeline = captureAutoStartedBySessionRecording
+        isSessionRecordingActive = false
+        sessionRecordingStartedAt = nil
+        captureAutoStartedBySessionRecording = false
+        menuBarState.setSessionRecording(false)
+        // Never leave a pipeline running that only this (failed) recording started.
+        if ownedPipeline, isCaptureRunning {
+            await stopCapturePipelineAsync()
         }
         statusItemController.refreshPresentation()
+    }
 
-        do {
-            let recordedSeconds = await sessionRecorder.recordedDurationSeconds()
-            guard recordedSeconds >= SavePreflight.minimumBufferedSeconds else {
-                await discardSessionRecording()
-                menuBarState.finishSaving(success: false)
-                isSessionFinalizeInProgress = false
-                statusItemController.refreshPresentation()
-                if userInitiated {
-                    NotificationManager.shared.showOperationalNotification(
-                        title: "Session Too Short",
-                        body: "Wait a moment after starting before stopping so there is something to save."
-                    )
-                }
-                return nil
-            }
+    // MARK: - Stop
 
-            let savedURL = try await sessionRecorder.saveEntireRecording(
-                outputDirectory: AppSettings.outputDirectoryURL,
-                mergeAudioTracks: AppSettings.mergeAudioTracks,
-                baseName: resolvedClipBaseName()
-            )
-            await sessionRecorder.configure(
-                enabled: false,
-                maxDurationSeconds: .infinity,
-                outputDirectory: AppSettings.outputDirectoryURL,
-                storage: .session
-            )
+    private func performStopScreenRecording(reason: SessionRecordingStopReason) async {
+        await finalizeSessionRecording(reason: reason, mayStopPipeline: true, revertAuxiliaryAudio: true)
+    }
 
-            menuBarState.finishSaving(success: true)
+    /// Hook for the pipeline teardown/reshape paths. Finalizes an *attached*
+    /// recording (samples flowing). `mayStopPipeline` is true only for the reshape
+    /// path (`applyPipelineShapeChanges`), which otherwise leaves an owned pipeline
+    /// running; the `stopCapturePipelineAsync` hook passes false because it is
+    /// already stopping the pipeline itself.
+    func finalizeSessionRecordingIfActive(
+        reason: SessionRecordingStopReason,
+        mayStopPipeline: Bool = false
+    ) async {
+        guard sessionAppendPump.isActive else { return }
+        await finalizeSessionRecording(
+            reason: reason,
+            mayStopPipeline: mayStopPipeline,
+            revertAuxiliaryAudio: false
+        )
+    }
+
+    /// Finalizes and saves the recording. The in-flight guard makes this safe to
+    /// call from overlapping paths (user stop, low-disk, pipeline teardown) — only
+    /// the first runs; the rest no-op.
+    private func finalizeSessionRecording(
+        reason: SessionRecordingStopReason,
+        mayStopPipeline: Bool,
+        revertAuxiliaryAudio: Bool
+    ) async {
+        guard isSessionRecordingActive, !isSessionFinalizeInProgress else { return }
+        isSessionFinalizeInProgress = true
+        defer { isSessionFinalizeInProgress = false }
+
+        // Stop sample flow, then show the same Saving… → Saved flash the replay
+        // save uses while the file finalizes and drains its queue.
+        sessionAppendPump.setActive(false)
+        let didBeginSaving = menuBarState.beginSaving()
+        statusItemController.refreshPresentation()
+
+        await sessionAppendPump.flush()
+        let savedURL = await sessionRecorder.stop()
+
+        let startedAt = sessionRecordingStartedAt
+        let ownedPipeline = captureAutoStartedBySessionRecording
+        let elapsed = startedAt.map { max(0, Date().timeIntervalSince($0)) } ?? 0
+        isSessionRecordingActive = false
+        sessionRecordingStartedAt = nil
+        captureAutoStartedBySessionRecording = false
+
+        menuBarState.setSessionRecording(false)
+        if let savedURL {
             statusItemController.setLastClip(savedURL)
-            isSessionFinalizeInProgress = false
-            statusItemController.refreshPresentation()
+        }
+        if didBeginSaving {
+            menuBarState.finishSaving(success: savedURL != nil)
+        }
+        announceScreenRecordingStop(savedURL: savedURL, elapsed: elapsed, reason: reason)
 
+        if mayStopPipeline, ownedPipeline, isCaptureRunning {
+            // The recording started the pipeline and nothing else needs it.
+            await stopCapturePipelineAsync()
+        } else if revertAuxiliaryAudio, isCaptureRunning {
+            // Replay keeps running: drop the mic the recording added if replay
+            // doesn't want it. System audio stays until the next full restart —
+            // dropping it now would briefly interrupt the replay buffer.
+            await applyMicSettingIfNeeded()
+        }
+
+        statusItemController.refreshPresentation()
+    }
+
+    /// Finalizes an in-progress recording during app termination, then stops
+    /// capture. Awaited from `applicationShouldTerminate` so the file is saved
+    /// before the process exits.
+    func finalizeSessionRecordingForTermination() async {
+        if isSessionRecordingActive {
+            await finalizeSessionRecording(reason: .userToggled, mayStopPipeline: false, revertAuxiliaryAudio: false)
+        }
+        await stopCapturePipelineAsync()
+    }
+
+    private func announceScreenRecordingStop(
+        savedURL: URL?,
+        elapsed: TimeInterval,
+        reason: SessionRecordingStopReason
+    ) {
+        if let savedURL {
             if AppSettings.playAudioCueOnSave {
                 AudioCue.playSaveSuccess()
             }
-            if AppSettings.showNotificationOnSave || !userInitiated {
-                NotificationManager.shared.showClipSavedNotification(
-                    fileURL: savedURL,
-                    clipDuration: recordedSeconds
-                )
+            if AppSettings.showNotificationOnSave {
+                NotificationManager.shared.showClipSavedNotification(fileURL: savedURL, clipDuration: elapsed)
             }
-            print("Session recording saved: \(savedURL.path)")
-            return savedURL
-        } catch LongBufferRecorderError.longBufferExportAlreadyInProgress {
-            await discardSessionRecording()
-            menuBarState.finishSaving(success: false)
-            isSessionFinalizeInProgress = false
-            statusItemController.refreshPresentation()
-            NotificationManager.shared.showOperationalNotification(
-                title: "Session Already Saving",
-                body: "Wait for the current export to finish before stopping another session."
+            if let stopBody = Self.stopReasonBody(reason, saved: true) {
+                NotificationManager.shared.showOperationalNotification(title: "Screen Recording Stopped", body: stopBody)
+            }
+            return
+        }
+
+        // No file. If the recording ran for a bit it means the writer failed;
+        // a sub-second recording is just a too-quick start→stop.
+        if elapsed >= 1 {
+            NotificationManager.shared.showSaveFailedNotification(
+                error: "The screen recording could not be finalized."
             )
-            return nil
-        } catch {
-            await discardSessionRecording()
-            menuBarState.finishSaving(success: false)
-            isSessionFinalizeInProgress = false
-            statusItemController.refreshPresentation()
-            NotificationManager.shared.showSaveFailedNotification(error: error.localizedDescription)
-            print("Failed to save session recording: \(error)")
-            return nil
+        } else if let stopBody = Self.stopReasonBody(reason, saved: false) {
+            NotificationManager.shared.showOperationalNotification(title: "Screen Recording Stopped", body: stopBody)
         }
     }
 
-    func discardSessionRecording() async {
-        isSessionRecording = false
-        menuBarState.setSessionRecording(false)
-        await sessionRecorder.configure(
-            enabled: false,
-            maxDurationSeconds: .infinity,
-            outputDirectory: AppSettings.outputDirectoryURL,
-            storage: .session
-        )
+    private static func stopReasonBody(_ reason: SessionRecordingStopReason, saved: Bool) -> String? {
+        let suffix = saved ? " The clip up to that point was saved." : ""
+        switch reason {
+        case .userToggled:
+            return nil
+        case .captureSettingsChanged:
+            return "Changing capture or encoding settings ended the recording.\(suffix)"
+        case .lowDisk:
+            return "The disk is almost full, so recording stopped.\(suffix)"
+        case .pipelineStopped:
+            return "Screen capture stopped, so the recording ended.\(suffix)"
+        }
     }
 }

--- a/Sources/App/AppDelegate.swift
+++ b/Sources/App/AppDelegate.swift
@@ -37,14 +37,13 @@ class AppDelegate: NSObject, NSApplicationDelegate, @unchecked Sendable {
         micRingBuffer: micAudioRingBuffer
     )
     let longBufferRecorder = LongBufferRecorder()
-    let sessionRecorder = LongBufferRecorder()
-    lazy var longBufferAppendPump = LongBufferAppendPump(
-        recorders: [longBufferRecorder, sessionRecorder]
-    )
-    /// True while a start→stop session recording is actively writing to disk.
-    var isSessionRecording = false
-    var isSessionFinalizeInProgress = false
-    var isTerminatingAfterSessionSave = false
+    lazy var longBufferAppendPump = LongBufferAppendPump(recorder: longBufferRecorder)
+
+    // Continuous "Screen Recording" — writes one MP4 by tapping the same encoded
+    // video stream and raw PCM audio the replay buffer uses, so it inherits every
+    // Video-section setting at no extra encode cost.
+    let sessionRecorder = SessionRecorder()
+    lazy var sessionAppendPump = SessionAppendPump(recorder: sessionRecorder)
 
     let menuBarState = MenuBarState()
     let statusItemController = StatusItemController()
@@ -55,6 +54,29 @@ class AppDelegate: NSObject, NSApplicationDelegate, @unchecked Sendable {
     /// is running. Ensures the game watcher only stops recordings it started,
     /// never a manual one.
     var recordingAutoStartedByGame = false
+
+    // MARK: - Screen recording state
+
+    /// True from the moment a screen recording begins until it fully stops.
+    /// Drives the capture union (`desiredSystemAudioForSCK`/`desiredMicEnabled`)
+    /// and the menu indicator. Distinct from `sessionAppendPump.isActive`, which
+    /// turns on only once samples are flowing — so a one-time pipeline restart at
+    /// recording start (to add system audio) doesn't trip the stop-on-reconfigure
+    /// finalize.
+    var isSessionRecordingActive = false
+    /// True while the capture pipeline was started solely to serve a screen
+    /// recording (replay buffer was idle). Ensures stopping the recording also
+    /// stops the pipeline it started — but never one replay or a game owns.
+    var captureAutoStartedBySessionRecording = false
+    var sessionWantsSystemAudio = false
+    var sessionWantsMicrophone = false
+    var sessionRecordingStartedAt: Date?
+    /// Serializes user start/stop so they can never interleave across awaits.
+    var sessionRecordingOpTask: Task<Void, Never>?
+    /// Guards against overlapping finalize (user stop, low-disk, pipeline teardown).
+    var isSessionFinalizeInProgress = false
+    /// True while termination is being delayed to finalize an in-progress recording.
+    var isTerminatingAfterSessionSave = false
 
     var isCaptureRunning = false
     var isWorkspaceSessionActive = true
@@ -142,9 +164,6 @@ class AppDelegate: NSObject, NSApplicationDelegate, @unchecked Sendable {
         statusItemController.onSaveLongBuffer = { [weak self] in
             self?.saveLongBufferFromUI()
         }
-        statusItemController.onToggleSessionRecording = { [weak self] in
-            self?.toggleSessionRecording()
-        }
         statusItemController.onToggleRecording = { [weak self] in
             self?.toggleCapturePipeline()
         }
@@ -153,6 +172,9 @@ class AppDelegate: NSObject, NSApplicationDelegate, @unchecked Sendable {
         }
         statusItemController.onOpenSettings = { [weak self] in
             self?.openSettingsWindow()
+        }
+        statusItemController.onToggleScreenRecording = { [weak self] in
+            self?.toggleScreenRecording()
         }
         statusItemController.setup(state: menuBarState)
         checkForAvailableUpdate()
@@ -208,24 +230,18 @@ class AppDelegate: NSObject, NSApplicationDelegate, @unchecked Sendable {
         monitoringTask?.cancel()
         settingsReconcileTask?.cancel()
         captureRecoveryTask?.cancel()
-        if !isTerminatingAfterSessionSave {
-            stopCapturePipeline()
-        }
+        stopCapturePipeline()
     }
 
     func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
-        // Finish an in-progress session recording before quitting so the file
-        // is not left as orphaned temp segments.
-        guard isSessionRecording || isSessionFinalizeInProgress else {
-            return .terminateNow
-        }
-        if isTerminatingAfterSessionSave {
+        // Delay termination just long enough to finalize an in-progress recording
+        // so the file is saved cleanly (not left as fragments).
+        guard isSessionRecordingActive, !isTerminatingAfterSessionSave else {
             return .terminateNow
         }
         isTerminatingAfterSessionSave = true
         Task { @MainActor in
-            await stopSessionRecording(userInitiated: false)
-            await stopCapturePipelineAsync()
+            await finalizeSessionRecordingForTermination()
             NSApp.reply(toApplicationShouldTerminate: true)
         }
         return .terminateLater

--- a/Sources/Capture/CaptureManager.swift
+++ b/Sources/Capture/CaptureManager.swift
@@ -27,6 +27,15 @@ public struct CaptureResolutionConfig: Sendable {
 
 public actor CaptureManager {
     private static let screenPixelFormat = kCVPixelFormatType_420YpCbCr8BiPlanarFullRange
+    // Pin the capture color space so ScreenCaptureKit tags every frame
+    // deterministically instead of leaving it to display-dependent defaults.
+    // The encoder tags its output BT.709 (sRGB primaries); keeping the source
+    // sRGB here keeps the pixel data and the tag aligned, which is what fixes
+    // the washed-out/desaturated saved clips. This must be applied at every
+    // SCStreamConfiguration site — including the runtime-update paths, which
+    // rebuild the configuration from scratch — or a live fps/bitrate/resolution
+    // change would drop it and desaturation would return.
+    private static let screenColorSpaceName = CGColorSpace.sRGB
 
     // Single-display state
     private var stream: SCStream?
@@ -79,6 +88,7 @@ public actor CaptureManager {
         config.minimumFrameInterval = CMTime(value: 1, timescale: CMTimeScale(fps))
         config.queueDepth = queueDepth
         config.pixelFormat = currentConfig.pixelFormat
+        config.colorSpaceName = Self.screenColorSpaceName
         config.capturesAudio = currentConfig.capturesAudio
         config.excludesCurrentProcessAudio = excludeOwnAppAudio
 
@@ -116,6 +126,7 @@ public actor CaptureManager {
         config1.minimumFrameInterval = CMTime(value: 1, timescale: CMTimeScale(fps))
         config1.queueDepth = queueDepth
         config1.pixelFormat = currentConfig1.pixelFormat
+        config1.colorSpaceName = Self.screenColorSpaceName
         config1.capturesAudio = currentConfig1.capturesAudio
         config1.excludesCurrentProcessAudio = excludeOwnAppAudio
 
@@ -125,6 +136,7 @@ public actor CaptureManager {
         config2.minimumFrameInterval = CMTime(value: 1, timescale: CMTimeScale(fps))
         config2.queueDepth = queueDepth
         config2.pixelFormat = currentConfig2.pixelFormat
+        config2.colorSpaceName = Self.screenColorSpaceName
         config2.capturesAudio = currentConfig2.capturesAudio
         config2.excludesCurrentProcessAudio = excludeOwnAppAudio
 
@@ -255,6 +267,7 @@ public actor CaptureManager {
         config.minimumFrameInterval = CMTime(value: 1, timescale: CMTimeScale(fps))
         config.queueDepth = queueDepth
         config.pixelFormat = Self.screenPixelFormat
+        config.colorSpaceName = Self.screenColorSpaceName
         config.capturesAudio = captureAudio
         config.excludesCurrentProcessAudio = excludeOwnAppAudio
 
@@ -347,6 +360,7 @@ public actor CaptureManager {
         config1.minimumFrameInterval = CMTime(value: 1, timescale: CMTimeScale(fps))
         config1.queueDepth = queueDepth
         config1.pixelFormat = Self.screenPixelFormat
+        config1.colorSpaceName = Self.screenColorSpaceName
         config1.capturesAudio = captureAudio
         config1.excludesCurrentProcessAudio = excludeOwnAppAudio
 
@@ -356,6 +370,7 @@ public actor CaptureManager {
         config2.minimumFrameInterval = CMTime(value: 1, timescale: CMTimeScale(fps))
         config2.queueDepth = queueDepth
         config2.pixelFormat = Self.screenPixelFormat
+        config2.colorSpaceName = Self.screenColorSpaceName
         config2.capturesAudio = false
 
         let newStream1 = SCStream(filter: filter1, configuration: config1, delegate: delegate1)

--- a/Sources/Capture/FrameCompositor.swift
+++ b/Sources/Capture/FrameCompositor.swift
@@ -26,7 +26,11 @@ public final class FrameCompositor: @unchecked Sendable {
     private var pixelBufferPool: CVPixelBufferPool?
     private var _outputHandler: OutputHandler?
     private let ciContext = CIContext(options: [.cacheIntermediates: false])
-    private let colorSpace = CGColorSpaceCreateDeviceRGB()
+    // Use an explicit sRGB working space (not generic device RGB) so the
+    // CoreImage YCbCr→RGB→YCbCr round-trip stays colorimetrically consistent
+    // with the sRGB/BT.709 tags the capture and encoder now apply. Prevents the
+    // dual side-by-side composite from drifting color vs single-display capture.
+    private let colorSpace = CGColorSpace(name: CGColorSpace.sRGB) ?? CGColorSpaceCreateDeviceRGB()
 
     private var primaryTimeoutCounter = 0
     private var secondaryTimeoutCounter = 0
@@ -140,10 +144,14 @@ public final class FrameCompositor: @unchecked Sendable {
             let primaryFrame = primary!
             let secondaryFrame = secondary!
             compositeFrameCount += 1
-            if compositeFrameCount <= 5 || compositeFrameCount % 60 == 0 {
-                print("FrameCompositor: composite #\(compositeFrameCount) PTS=\(pts.seconds) valid=\(pts.isValid)")
-            }
+            let loggedFrameCount = compositeFrameCount
             lock.unlock()
+
+            // Log outside the lock — a blocking stdout write must not stall the
+            // capture-push threads that contend for it.
+            if loggedFrameCount <= 5 || loggedFrameCount % 60 == 0 {
+                print("FrameCompositor: composite #\(loggedFrameCount) PTS=\(pts.seconds) valid=\(pts.isValid)")
+            }
 
             let compositeBuffer = composite(
                 primary: primaryFrame,

--- a/Sources/Encode/VideoEncoder.swift
+++ b/Sources/Encode/VideoEncoder.swift
@@ -43,6 +43,7 @@ public final class VideoEncoder: @unchecked Sendable {
     private var _currentConfiguration: VideoEncoderConfiguration?
     private var expectedPTSQueue: [CMTime] = []
     private var encodeCount: Int64 = 0
+    private var _forceKeyframeNextFrame = false
 
     public var outputHandler: OutputHandler? {
         get {
@@ -126,7 +127,17 @@ public final class VideoEncoder: @unchecked Sendable {
             kVTCompressionPropertyKey_DataRateLimits: [
                 NSNumber(value: bytesPerSecond * 1.5),
                 NSNumber(value: 1.0)
-            ] as NSArray
+            ] as NSArray,
+            // Tag the encoded stream BT.709 (sRGB primaries) so the MP4 carries an
+            // explicit `colr` atom. Without this the color info is left ambiguous
+            // and players apply a mismatched matrix/range, which shows up as
+            // washed-out/desaturated clips. The capture side is pinned to sRGB
+            // (CaptureManager.screenColorSpaceName) so the pixel data matches these
+            // tags. Applies to both HEVC and H.264, and to every consumer of the
+            // encoded stream (replay buffer clips and the screen recorder alike).
+            kVTCompressionPropertyKey_ColorPrimaries: kCMFormatDescriptionColorPrimaries_ITU_R_709_2,
+            kVTCompressionPropertyKey_TransferFunction: kCMFormatDescriptionTransferFunction_ITU_R_709_2,
+            kVTCompressionPropertyKey_YCbCrMatrix: kCMFormatDescriptionYCbCrMatrix_ITU_R_709_2
         ]
 
         let propsStatus = VTSessionSetProperties(session, propertyDictionary: properties as CFDictionary)
@@ -153,9 +164,19 @@ public final class VideoEncoder: @unchecked Sendable {
         stateLock.unlock()
     }
 
+    /// Requests that the next encoded frame be a keyframe (IDR). Used when a
+    /// screen recording starts so its file can open on a decodable frame instead
+    /// of a mid-GOP P-frame (which renders black until the next keyframe).
+    public func forceNextKeyframe() {
+        stateLock.lock()
+        _forceKeyframeNextFrame = true
+        stateLock.unlock()
+    }
+
     public func encode(sampleBuffer: CMSampleBuffer) {
         stateLock.lock()
         let session = compressionSession
+        let forceKeyframe = _forceKeyframeNextFrame
         stateLock.unlock()
 
         guard let session else { return }
@@ -169,12 +190,16 @@ public final class VideoEncoder: @unchecked Sendable {
         encodeCount += 1
         stateLock.unlock()
 
+        let frameProperties: CFDictionary? = forceKeyframe
+            ? [kVTEncodeFrameOptionKey_ForceKeyFrame: kCFBooleanTrue] as CFDictionary
+            : nil
+
         let status = VTCompressionSessionEncodeFrame(
             session,
             imageBuffer: pixelBuffer,
             presentationTimeStamp: pts,
             duration: duration,
-            frameProperties: nil,
+            frameProperties: frameProperties,
             sourceFrameRefcon: nil,
             infoFlagsOut: nil
         )
@@ -184,6 +209,12 @@ public final class VideoEncoder: @unchecked Sendable {
             _ = expectedPTSQueue.popLast()
             stateLock.unlock()
             print("Encoder: VTCompressionSessionEncodeFrame failed with status \(status)")
+        } else if forceKeyframe {
+            // Consume the one-shot keyframe request only once the frame was
+            // actually submitted, so a dropped/failed frame doesn't lose it.
+            stateLock.lock()
+            _forceKeyframeNextFrame = false
+            stateLock.unlock()
         }
     }
 

--- a/Sources/Hotkeys/HotkeyManager.swift
+++ b/Sources/Hotkeys/HotkeyManager.swift
@@ -8,8 +8,8 @@ public final class HotkeyManager: @unchecked Sendable {
     public var onSaveLast15Seconds: (() -> Void)?
     public var onSaveLast60Seconds: (() -> Void)?
     public var onSaveLongBuffer: (() -> Void)?
-    public var onToggleSessionRecording: (() -> Void)?
     public var onOpenClipLibrary: (() -> Void)?
+    public var onToggleScreenRecording: (() -> Void)?
 
     private var isStarted = false
 
@@ -21,8 +21,8 @@ public final class HotkeyManager: @unchecked Sendable {
         KeyboardShortcuts.removeHandler(for: .saveLast15Seconds)
         KeyboardShortcuts.removeHandler(for: .saveLast60Seconds)
         KeyboardShortcuts.removeHandler(for: .saveLongBuffer)
-        KeyboardShortcuts.removeHandler(for: .toggleSessionRecording)
         KeyboardShortcuts.removeHandler(for: .openClipLibrary)
+        KeyboardShortcuts.removeHandler(for: .toggleScreenRecording)
     }
 
     public func start() {
@@ -46,11 +46,11 @@ public final class HotkeyManager: @unchecked Sendable {
         KeyboardShortcuts.onKeyUp(for: .saveLongBuffer) { [weak self] in
             self?.onSaveLongBuffer?()
         }
-        KeyboardShortcuts.onKeyUp(for: .toggleSessionRecording) { [weak self] in
-            self?.onToggleSessionRecording?()
-        }
         KeyboardShortcuts.onKeyUp(for: .openClipLibrary) { [weak self] in
             self?.onOpenClipLibrary?()
+        }
+        KeyboardShortcuts.onKeyUp(for: .toggleScreenRecording) { [weak self] in
+            self?.onToggleScreenRecording?()
         }
     }
 }

--- a/Sources/Hotkeys/HotkeyNames.swift
+++ b/Sources/Hotkeys/HotkeyNames.swift
@@ -6,6 +6,6 @@ public extension KeyboardShortcuts.Name {
     static let saveLast15Seconds = Self("saveLast15Seconds")
     static let saveLast60Seconds = Self("saveLast60Seconds")
     static let saveLongBuffer = Self("saveLongBuffer")
-    static let toggleSessionRecording = Self("toggleSessionRecording")
     static let openClipLibrary = Self("openClipLibrary")
+    static let toggleScreenRecording = Self("toggleScreenRecording")
 }

--- a/Sources/Save/LongBufferAppendPump.swift
+++ b/Sources/Save/LongBufferAppendPump.swift
@@ -12,7 +12,7 @@ public final class LongBufferAppendPump: @unchecked Sendable {
         case microphone(LongBufferSample)
     }
 
-    private let recorders: [LongBufferRecorder]
+    private let recorder: LongBufferRecorder
     private let queue = DispatchQueue(label: "com.replaycap.long-buffer.append-pump", qos: .userInitiated)
     private let maxPendingSamples: Int
     private var pendingSamples: [PendingSample] = []
@@ -20,25 +20,41 @@ public final class LongBufferAppendPump: @unchecked Sendable {
     private var drainGeneration = 0
     private var droppedSamples = 0
 
+    // Extended-replay is off by default. Gate here so an idle long buffer doesn't
+    // spin a GCD block + Task + actor hop per frame only for the recorder to
+    // discard it. Read on the capture thread, set on the main actor.
+    private let flagsLock = NSLock()
+    private var _isEnabled = false
+
     public init(recorder: LongBufferRecorder, maxPendingSamples: Int = 240) {
-        self.recorders = [recorder]
+        self.recorder = recorder
         self.maxPendingSamples = max(1, maxPendingSamples)
     }
 
-    public init(recorders: [LongBufferRecorder], maxPendingSamples: Int = 240) {
-        self.recorders = recorders
-        self.maxPendingSamples = max(1, maxPendingSamples)
+    public var isEnabled: Bool {
+        flagsLock.lock()
+        defer { flagsLock.unlock() }
+        return _isEnabled
+    }
+
+    public func setEnabled(_ enabled: Bool) {
+        flagsLock.lock()
+        _isEnabled = enabled
+        flagsLock.unlock()
     }
 
     public func enqueueVideo(_ sample: LongBufferSample) {
+        guard isEnabled else { return }
         enqueue(.video(sample))
     }
 
     public func enqueueSystemAudio(_ sample: LongBufferSample) {
+        guard isEnabled else { return }
         enqueue(.systemAudio(sample))
     }
 
     public func enqueueMicrophone(_ sample: LongBufferSample) {
+        guard isEnabled else { return }
         enqueue(.microphone(sample))
     }
 
@@ -89,21 +105,14 @@ public final class LongBufferAppendPump: @unchecked Sendable {
         }
 
         let sample = pendingSamples.removeFirst()
-        let recorders = self.recorders
-        Task { [weak self] in
+        Task { [weak self, recorder] in
             switch sample {
             case .video(let sample):
-                for recorder in recorders {
-                    await recorder.appendVideo(sample)
-                }
+                await recorder.appendVideo(sample)
             case .systemAudio(let sample):
-                for recorder in recorders {
-                    await recorder.appendSystemAudio(sample)
-                }
+                await recorder.appendSystemAudio(sample)
             case .microphone(let sample):
-                for recorder in recorders {
-                    await recorder.appendMicrophone(sample)
-                }
+                await recorder.appendMicrophone(sample)
             }
 
             self?.queue.async { [weak self] in

--- a/Sources/Save/LongBufferRecorder.swift
+++ b/Sources/Save/LongBufferRecorder.swift
@@ -29,50 +29,6 @@ public enum LongBufferRecorderError: LocalizedError, Equatable {
     }
 }
 
-/// On-disk layout for a continuous disk writer. Long buffer and session recording
-/// share the same writer implementation but must never share directories or file
-/// prefixes, or orphan cleanup from one mode would delete the other's segments.
-public struct LongBufferStorageConfig: Sendable, Equatable {
-    public let segmentDirectoryName: String
-    public let legacySegmentDirectoryName: String?
-    public let segmentFilePrefix: String
-    public let legacySegmentFilePrefix: String?
-    public let exportStagingDirectoryName: String
-    public let outputSuffix: String
-
-    public init(
-        segmentDirectoryName: String,
-        legacySegmentDirectoryName: String? = nil,
-        segmentFilePrefix: String,
-        legacySegmentFilePrefix: String? = nil,
-        exportStagingDirectoryName: String,
-        outputSuffix: String
-    ) {
-        self.segmentDirectoryName = segmentDirectoryName
-        self.legacySegmentDirectoryName = legacySegmentDirectoryName
-        self.segmentFilePrefix = segmentFilePrefix
-        self.legacySegmentFilePrefix = legacySegmentFilePrefix
-        self.exportStagingDirectoryName = exportStagingDirectoryName
-        self.outputSuffix = outputSuffix
-    }
-
-    public static let longBuffer = LongBufferStorageConfig(
-        segmentDirectoryName: ".ReplayCapLongBuffer",
-        legacySegmentDirectoryName: ".ReplayMacLongBuffer",
-        segmentFilePrefix: "ReplayCap_LongBuffer",
-        legacySegmentFilePrefix: "ReplayMac_LongBuffer",
-        exportStagingDirectoryName: ".ReplayCapLongBufferExports",
-        outputSuffix: "LongBuffer"
-    )
-
-    public static let session = LongBufferStorageConfig(
-        segmentDirectoryName: ".ReplayCapSession",
-        segmentFilePrefix: "ReplayCap_Session",
-        exportStagingDirectoryName: ".ReplayCapSessionExports",
-        outputSuffix: "Session"
-    )
-}
-
 public struct LongBufferSample: @unchecked Sendable {
     public let buffer: CMSampleBuffer
 
@@ -96,8 +52,7 @@ public actor LongBufferRecorder {
         TimeInterval,
         URL,
         Bool,
-        String?,
-        String
+        String?
     ) async throws -> URL
 
     private struct Segment: Sendable {
@@ -115,8 +70,6 @@ public actor LongBufferRecorder {
     private let segmentSeconds: Double = 60
     private var isEnabled = false
     private var maxDurationSeconds: Double = 300
-    private var storageConfig: LongBufferStorageConfig = .longBuffer
-    private var outputDirectory: URL?
     private var segmentDirectory: URL?
     private var segments: [Segment] = []
     private var latestVideoPTS: Double?
@@ -156,32 +109,17 @@ public actor LongBufferRecorder {
         self.clipExporter = clipExporter
     }
 
-    public func isRecordingEnabled() -> Bool {
-        isEnabled
-    }
-
-    /// Wall-clock span of retained media, including the in-progress segment.
-    public func recordedDurationSeconds() -> TimeInterval {
-        let ends = segments.map(\.endPTS) + (activeSegmentEndPTS.map { [$0] } ?? [])
-        let starts = segments.map(\.startPTS) + (activeSegmentStartPTS.map { [$0] } ?? [])
-        guard let newest = ends.max(), let oldest = starts.min() else {
-            return 0
-        }
-        return max(0, newest - oldest)
-    }
-
     public func configure(
         enabled: Bool,
         maxDurationSeconds: TimeInterval,
-        outputDirectory: URL,
-        storage: LongBufferStorageConfig = .longBuffer
+        outputDirectory: URL
     ) async {
         isEnabled = enabled
         self.maxDurationSeconds = maxDurationSeconds
-        self.storageConfig = storage
-        self.outputDirectory = outputDirectory
         let requestedSegmentDirectory = outputDirectory
-            .appendingPathComponent(storage.segmentDirectoryName, isDirectory: true)
+            .appendingPathComponent(".ReplayCapLongBuffer", isDirectory: true)
+        let legacySegmentDirectory = outputDirectory
+            .appendingPathComponent(".ReplayMacLongBuffer", isDirectory: true)
         segmentDirectory = requestedSegmentDirectory
         droppedVideoSamples = 0
         droppedSystemAudioSamples = 0
@@ -189,11 +127,7 @@ public actor LongBufferRecorder {
         latestVideoPTS = nil
 
         cleanupOrphanedSegmentsIfNeeded(in: requestedSegmentDirectory)
-        if let legacyName = storage.legacySegmentDirectoryName {
-            cleanupOrphanedSegmentsIfNeeded(
-                in: outputDirectory.appendingPathComponent(legacyName, isDirectory: true)
-            )
-        }
+        cleanupOrphanedSegmentsIfNeeded(in: legacySegmentDirectory)
 
         if !enabled {
             await stop(deleteSegments: true)
@@ -271,42 +205,6 @@ public actor LongBufferRecorder {
         mergeAudioTracks: Bool = true,
         baseName: String? = nil
     ) async throws -> URL {
-        try await saveClip(
-            lastSeconds: lastSeconds,
-            outputDirectory: outputDirectory,
-            mergeAudioTracks: mergeAudioTracks,
-            baseName: baseName,
-            outputSuffix: storageConfig.outputSuffix
-        )
-    }
-
-    /// Finishes the active segment and exports every retained segment (full session).
-    public func saveEntireRecording(
-        outputDirectory: URL,
-        mergeAudioTracks: Bool = true,
-        baseName: String? = nil
-    ) async throws -> URL {
-        try await finishCurrentSegment()
-        let duration = recordedDurationSeconds()
-        guard duration > 0 || !segments.isEmpty else {
-            throw LongBufferRecorderError.noSegments
-        }
-        return try await saveClip(
-            lastSeconds: max(duration + 1, 1),
-            outputDirectory: outputDirectory,
-            mergeAudioTracks: mergeAudioTracks,
-            baseName: baseName,
-            outputSuffix: storageConfig.outputSuffix
-        )
-    }
-
-    private func saveClip(
-        lastSeconds: TimeInterval,
-        outputDirectory: URL,
-        mergeAudioTracks: Bool,
-        baseName: String?,
-        outputSuffix: String
-    ) async throws -> URL {
         let exportID = UUID().uuidString
         guard !isExportInProgress else {
             logger.notice(
@@ -362,8 +260,7 @@ public actor LongBufferRecorder {
             let staged = try await Self.stageSegments(
                 selectedSegments,
                 outputDirectory: outputDirectory,
-                exportID: exportID,
-                stagingDirectoryName: storageConfig.exportStagingDirectoryName
+                exportID: exportID
             )
             stagingDirectory = staged.directory
             logger.info(
@@ -382,8 +279,7 @@ public actor LongBufferRecorder {
                 lastSeconds,
                 outputDirectory,
                 mergeAudioTracks,
-                baseName,
-                outputSuffix
+                baseName
             )
 
             await cleanupStagingDirectory(staged.directory, exportID: exportID)
@@ -410,8 +306,7 @@ public actor LongBufferRecorder {
         lastSeconds: TimeInterval,
         outputDirectory: URL,
         mergeAudioTracks: Bool,
-        baseName: String?,
-        outputSuffix: String
+        baseName: String?
     ) async throws -> URL {
         let newestPTS = segments.map(\.endPTS).max() ?? 0
         let cutoffPTS = newestPTS - lastSeconds
@@ -458,11 +353,7 @@ public actor LongBufferRecorder {
             cursor = CMTimeAdd(cursor, localDuration)
         }
 
-        let outputURL = try ClipMetadata.generateUniqueFileURL(
-            in: outputDirectory,
-            baseName: baseName,
-            suffix: outputSuffix
-        )
+        let outputURL = try ClipMetadata.generateUniqueFileURL(in: outputDirectory, baseName: baseName, suffix: "LongBuffer")
         let preset: String
         if mergeAudioTracks, compositionAudioTracks.count > 1 {
             preset = AVAssetExportPresetHighestQuality
@@ -495,11 +386,10 @@ public actor LongBufferRecorder {
     private static func stageSegments(
         _ segments: [Segment],
         outputDirectory: URL,
-        exportID: String,
-        stagingDirectoryName: String
+        exportID: String
     ) async throws -> StagedExport {
         let stagingRoot = outputDirectory
-            .appendingPathComponent(stagingDirectoryName, isDirectory: true)
+            .appendingPathComponent(".ReplayCapLongBufferExports", isDirectory: true)
         let stagingDirectory = stagingRoot.appendingPathComponent(exportID, isDirectory: true)
 
         return try await Task.detached(priority: .userInitiated) {
@@ -566,7 +456,7 @@ public actor LongBufferRecorder {
         guard let segmentDirectory else { return }
         try FileManager.default.createDirectory(at: segmentDirectory, withIntermediateDirectories: true)
 
-        let fileName = "\(storageConfig.segmentFilePrefix)_\(Int(Date().timeIntervalSince1970))_\(UUID().uuidString).mp4"
+        let fileName = "ReplayCap_LongBuffer_\(Int(Date().timeIntervalSince1970))_\(UUID().uuidString).mp4"
         let url = segmentDirectory.appendingPathComponent(fileName)
         var installedWriter = false
         defer {
@@ -801,9 +691,6 @@ public actor LongBufferRecorder {
     }
 
     private func pruneSegments(keepingNewestPTS newestPTS: Double) {
-        guard maxDurationSeconds.isFinite, maxDurationSeconds > 0 else {
-            return
-        }
         let cutoff = newestPTS - maxDurationSeconds
         let expired = segments.filter { $0.endPTS < cutoff }
         segments.removeAll { $0.endPTS < cutoff }
@@ -917,13 +804,9 @@ public actor LongBufferRecorder {
     }
 
     private func isReplayCapSegmentFile(_ url: URL) -> Bool {
-        guard url.pathExtension.lowercased() == "mp4" else {
-            return false
-        }
-        let name = url.lastPathComponent
-        let matchesPrimary = name.hasPrefix(storageConfig.segmentFilePrefix + "_")
-        let matchesLegacy = storageConfig.legacySegmentFilePrefix.map { name.hasPrefix($0 + "_") } ?? false
-        guard matchesPrimary || matchesLegacy else {
+        guard url.pathExtension.lowercased() == "mp4",
+              url.lastPathComponent.hasPrefix("ReplayCap_LongBuffer_")
+                || url.lastPathComponent.hasPrefix("ReplayMac_LongBuffer_") else {
             return false
         }
         return (try? url.resourceValues(forKeys: [.isRegularFileKey]).isRegularFile) == true

--- a/Sources/Save/SessionAppendPump.swift
+++ b/Sources/Save/SessionAppendPump.swift
@@ -1,0 +1,189 @@
+import Foundation
+
+public struct SessionAppendStats: Sendable {
+    public let pendingSamples: Int
+    public let droppedSamples: Int
+}
+
+/// Decouples the real-time capture/encode callbacks from the `SessionRecorder`
+/// actor. Mirrors `LongBufferAppendPump` (bounded queue, drop-oldest under
+/// pressure, single generation-guarded drain loop) and adds the gating flags the
+/// output handlers read to decide whether a sample belongs to the current screen
+/// recording. Enqueue and the flag reads run on capture/VideoToolbox threads, so
+/// nothing here hops to the main actor.
+public final class SessionAppendPump: @unchecked Sendable {
+    private enum PendingSample {
+        case video(LongBufferSample)
+        case systemAudio(LongBufferSample)
+        case microphone(LongBufferSample)
+    }
+
+    private let recorder: SessionRecorder
+    private let queue = DispatchQueue(label: "com.replaycap.session.append-pump", qos: .userInitiated)
+    private let maxPendingSamples: Int
+    private var pendingSamples: [PendingSample] = []
+    private var isDraining = false
+    private var drainGeneration = 0
+    private var droppedSamples = 0
+    private var flushContinuations: [CheckedContinuation<Void, Never>] = []
+
+    // Gating flags, read on real-time capture threads. Guarded independently of
+    // the drain queue so the reads never block behind queued work.
+    private let flagsLock = NSLock()
+    private var _isActive = false
+    private var _wantsSystemAudio = false
+    private var _wantsMicrophone = false
+
+    public init(recorder: SessionRecorder, maxPendingSamples: Int = 240) {
+        self.recorder = recorder
+        self.maxPendingSamples = max(1, maxPendingSamples)
+    }
+
+    // MARK: - Gating
+
+    /// Whether the current recording is capturing system audio. The SCK
+    /// system-audio process gate ORs this with the replay buffer's own setting.
+    public var systemAudioWanted: Bool {
+        flagsLock.lock()
+        defer { flagsLock.unlock() }
+        return _isActive && _wantsSystemAudio
+    }
+
+    public var isActive: Bool {
+        flagsLock.lock()
+        defer { flagsLock.unlock() }
+        return _isActive
+    }
+
+    public var microphoneWanted: Bool {
+        flagsLock.lock()
+        defer { flagsLock.unlock() }
+        return _isActive && _wantsMicrophone
+    }
+
+    public func configure(recordSystemAudio: Bool, recordMicrophone: Bool) {
+        flagsLock.lock()
+        _wantsSystemAudio = recordSystemAudio
+        _wantsMicrophone = recordMicrophone
+        flagsLock.unlock()
+    }
+
+    public func setActive(_ active: Bool) {
+        flagsLock.lock()
+        _isActive = active
+        flagsLock.unlock()
+    }
+
+    // MARK: - Enqueue
+
+    public func enqueueVideo(_ sample: LongBufferSample) {
+        guard isActive else { return }
+        enqueue(.video(sample))
+    }
+
+    public func enqueueSystemAudio(_ sample: LongBufferSample) {
+        flagsLock.lock()
+        let wanted = _isActive && _wantsSystemAudio
+        flagsLock.unlock()
+        guard wanted else { return }
+        enqueue(.systemAudio(sample))
+    }
+
+    public func enqueueMicrophone(_ sample: LongBufferSample) {
+        flagsLock.lock()
+        let wanted = _isActive && _wantsMicrophone
+        flagsLock.unlock()
+        guard wanted else { return }
+        enqueue(.microphone(sample))
+    }
+
+    // MARK: - Lifecycle
+
+    public func reset() {
+        queue.async { [weak self] in
+            guard let self else { return }
+            self.pendingSamples.removeAll(keepingCapacity: true)
+            self.isDraining = false
+            self.drainGeneration += 1
+            self.droppedSamples = 0
+            self.resumeFlushContinuations()
+        }
+    }
+
+    /// Awaits until every already-enqueued sample has been handed to the
+    /// recorder. Call after `setActive(false)` and before `recorder.stop()` so
+    /// the finalized file contains all captured frames.
+    public func flush() async {
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            queue.async { [weak self] in
+                guard let self else { continuation.resume(); return }
+                if self.pendingSamples.isEmpty && !self.isDraining {
+                    continuation.resume()
+                } else {
+                    self.flushContinuations.append(continuation)
+                }
+            }
+        }
+    }
+
+    public func snapshot() -> SessionAppendStats {
+        queue.sync {
+            SessionAppendStats(pendingSamples: pendingSamples.count, droppedSamples: droppedSamples)
+        }
+    }
+
+    // MARK: - Drain
+
+    private func enqueue(_ sample: PendingSample) {
+        queue.async { [weak self] in
+            guard let self else { return }
+            if self.pendingSamples.count >= self.maxPendingSamples {
+                self.pendingSamples.removeFirst()
+                self.droppedSamples += 1
+            }
+            self.pendingSamples.append(sample)
+            self.startDrainIfNeeded()
+        }
+    }
+
+    private func startDrainIfNeeded() {
+        guard !isDraining else { return }
+        guard !pendingSamples.isEmpty else { return }
+        isDraining = true
+        drainNext(generation: drainGeneration)
+    }
+
+    private func drainNext(generation: Int) {
+        guard generation == drainGeneration else { return }
+        guard !pendingSamples.isEmpty else {
+            isDraining = false
+            resumeFlushContinuations()
+            return
+        }
+
+        let sample = pendingSamples.removeFirst()
+        Task { [weak self, recorder] in
+            switch sample {
+            case .video(let sample):
+                await recorder.appendVideo(sample)
+            case .systemAudio(let sample):
+                await recorder.appendSystemAudio(sample)
+            case .microphone(let sample):
+                await recorder.appendMicrophone(sample)
+            }
+
+            self?.queue.async { [weak self] in
+                self?.drainNext(generation: generation)
+            }
+        }
+    }
+
+    private func resumeFlushContinuations() {
+        guard !flushContinuations.isEmpty else { return }
+        let continuations = flushContinuations
+        flushContinuations.removeAll(keepingCapacity: true)
+        for continuation in continuations {
+            continuation.resume()
+        }
+    }
+}

--- a/Sources/Save/SessionRecorder.swift
+++ b/Sources/Save/SessionRecorder.swift
@@ -1,0 +1,389 @@
+import Foundation
+@preconcurrency import AVFoundation
+@preconcurrency import CoreMedia
+import os.log
+
+public enum SessionRecorderError: LocalizedError, Equatable {
+    case cannotAddInput
+    case cannotStartWriting
+    case finalizeFailed
+
+    public var errorDescription: String? {
+        switch self {
+        case .cannotAddInput:
+            return "Unable to add a track to the screen recording writer."
+        case .cannotStartWriting:
+            return "Unable to start the screen recording writer."
+        case .finalizeFailed:
+            return "Screen recording did not finalize."
+        }
+    }
+}
+
+/// Writes one continuous MP4 for a manual "Screen Recording" session by tapping
+/// the already-encoded video stream (muxed with no re-encode) and the raw PCM
+/// audio streams (AAC-encoded by the writer). Modeled on `LongBufferRecorder`,
+/// but a single file with no segment rotation, pruning, or staging. The writer is
+/// built lazily on the first video frame (it needs the encoded format
+/// description) and only while the session is `.recording`, so a late-draining
+/// frame after `stop()` can never spawn a second file.
+public actor SessionRecorder {
+    typealias WriterBuilder = @Sendable (
+        _ outputURL: URL,
+        _ firstVideo: LongBufferSample,
+        _ startPTS: Double,
+        _ includeSystemAudio: Bool,
+        _ includeMicrophone: Bool
+    ) throws -> LongBufferWriterComponents
+    typealias WriterFinisher = @Sendable (LongBufferWriterBox) async throws -> Void
+
+    private enum State: Equatable {
+        case idle
+        case recording
+        case finalizing
+        case finished
+    }
+
+    private var state: State = .idle
+    private var writer: AVAssetWriter?
+    private var videoInput: AVAssetWriterInput?
+    private var systemAudioInput: AVAssetWriterInput?
+    private var micInput: AVAssetWriterInput?
+
+    private var outputDirectory: URL?
+    private var baseName: String?
+    private var includeSystemAudio = false
+    private var includeMicrophone = false
+    private var sessionStartPTS: Double?
+    private var outputURL: URL?
+    private var writerDidFail = false
+
+    private var droppedVideoSamples = 0
+    private var droppedSystemAudioSamples = 0
+    private var droppedMicSamples = 0
+
+    private let writerBuilder: WriterBuilder
+    private let writerFinisher: WriterFinisher
+    private let logger = Logger(subsystem: "com.replaycap", category: "SessionRecorder")
+
+    public init() {
+        writerBuilder = Self.makeWriter
+        writerFinisher = Self.finishWriter
+    }
+
+    init(writerBuilder: @escaping WriterBuilder, writerFinisher: @escaping WriterFinisher) {
+        self.writerBuilder = writerBuilder
+        self.writerFinisher = writerFinisher
+    }
+
+    public var isRecording: Bool { state == .recording }
+
+    /// Arms a new recording. The writer is created on the first video frame.
+    public func start(
+        outputDirectory: URL,
+        recordSystemAudio: Bool,
+        recordMicrophone: Bool,
+        baseName: String?
+    ) {
+        writer = nil
+        videoInput = nil
+        systemAudioInput = nil
+        micInput = nil
+        sessionStartPTS = nil
+        outputURL = nil
+        writerDidFail = false
+        droppedVideoSamples = 0
+        droppedSystemAudioSamples = 0
+        droppedMicSamples = 0
+
+        self.outputDirectory = outputDirectory
+        self.baseName = baseName
+        includeSystemAudio = recordSystemAudio
+        includeMicrophone = recordMicrophone
+        state = .recording
+    }
+
+    public func appendVideo(_ sample: LongBufferSample) {
+        guard state == .recording else { return }
+        let buffer = sample.buffer
+        guard buffer.isValid else { return }
+
+        do {
+            if writer == nil {
+                guard !writerDidFail else { return }
+                // Open the file on a keyframe (IDR) so it starts on a decodable
+                // frame. Starting mid-GOP on a P-frame renders black until the
+                // next keyframe. The encoder is asked to emit a keyframe right
+                // when recording starts, so this drops at most a frame or two.
+                guard Self.isKeyframe(buffer) else { return }
+                // PTS is only needed to anchor the first frame's session start.
+                try startWriter(firstVideo: buffer, at: presentationTimeStamp(buffer))
+            }
+            if !append(buffer, to: videoInput) {
+                droppedVideoSamples += 1
+                logDropIfNeeded(label: "video", count: droppedVideoSamples)
+                noteTerminalFailureIfNeeded()
+            }
+        } catch {
+            writerDidFail = true
+            logger.error(
+                "Session recorder video append failed error=\(error.localizedDescription, privacy: .public)"
+            )
+        }
+    }
+
+    public func appendSystemAudio(_ sample: LongBufferSample) {
+        guard state == .recording, includeSystemAudio else { return }
+        if !appendAudio(sample.buffer, to: systemAudioInput) {
+            droppedSystemAudioSamples += 1
+            logDropIfNeeded(label: "system audio", count: droppedSystemAudioSamples)
+        }
+    }
+
+    public func appendMicrophone(_ sample: LongBufferSample) {
+        guard state == .recording, includeMicrophone else { return }
+        if !appendAudio(sample.buffer, to: micInput) {
+            droppedMicSamples += 1
+            logDropIfNeeded(label: "microphone", count: droppedMicSamples)
+        }
+    }
+
+    /// Finalizes the current recording. Returns the saved file URL, or `nil` if
+    /// no frame was ever written or finalization failed.
+    @discardableResult
+    public func stop() async -> URL? {
+        guard state == .recording else { return nil }
+        state = .finalizing
+
+        guard let writer, let outputURL else {
+            clearWriter()
+            state = .finished
+            return nil
+        }
+
+        // Detach the writer/inputs before awaiting. Actor methods are re-entrant
+        // at suspension points, so a late-draining append must not see inputs that
+        // have already been marked finished.
+        let videoInput = self.videoInput
+        let systemAudioInput = self.systemAudioInput
+        let micInput = self.micInput
+        clearWriter()
+
+        videoInput?.markAsFinished()
+        systemAudioInput?.markAsFinished()
+        micInput?.markAsFinished()
+
+        do {
+            try await writerFinisher(LongBufferWriterBox(writer))
+            state = .finished
+            NotificationCenter.default.post(name: .replayCapClipSaved, object: outputURL)
+            logger.info(
+                "Session recording finalized file=\(outputURL.lastPathComponent, privacy: .public)"
+            )
+            return outputURL
+        } catch {
+            state = .finished
+            try? FileManager.default.removeItem(at: outputURL)
+            logger.error(
+                "Session recording finalize failed error=\(error.localizedDescription, privacy: .public)"
+            )
+            return nil
+        }
+    }
+
+    // MARK: - Writer lifecycle
+
+    private func startWriter(firstVideo: CMSampleBuffer, at pts: Double) throws {
+        guard let outputDirectory else { throw SessionRecorderError.cannotStartWriting }
+        let url = try ClipMetadata.generateUniqueFileURL(
+            in: outputDirectory,
+            baseName: baseName,
+            suffix: "Recording"
+        )
+        var installed = false
+        defer {
+            if !installed {
+                try? FileManager.default.removeItem(at: url)
+            }
+        }
+
+        let components = try writerBuilder(
+            url,
+            LongBufferSample(firstVideo),
+            pts,
+            includeSystemAudio,
+            includeMicrophone
+        )
+        writer = components.writer
+        videoInput = components.videoInput
+        systemAudioInput = components.systemAudioInput
+        micInput = components.micInput
+        outputURL = url
+        sessionStartPTS = pts
+        installed = true
+        logger.info(
+            "Session recording writer started file=\(url.lastPathComponent, privacy: .public) sysAudio=\(self.includeSystemAudio, privacy: .public) mic=\(self.includeMicrophone, privacy: .public)"
+        )
+    }
+
+    private func clearWriter() {
+        writer = nil
+        videoInput = nil
+        systemAudioInput = nil
+        micInput = nil
+    }
+
+    private func appendAudio(_ sample: CMSampleBuffer, to input: AVAssetWriterInput?) -> Bool {
+        guard sample.isValid else { return true }
+        // No writer yet (audio arrived before the first video frame), or audio
+        // whose PTS precedes the session start: drop it so the timeline anchors to
+        // the first video frame and never predates startSession. Not a real drop.
+        guard writer != nil, let sessionStartPTS else { return true }
+        let pts = presentationTimeStamp(sample)
+        guard pts >= sessionStartPTS else { return true }
+        return append(sample, to: input)
+    }
+
+    private func append(_ sample: CMSampleBuffer, to input: AVAssetWriterInput?) -> Bool {
+        guard let writer, writer.status == .writing, let input, input.isReadyForMoreMediaData else {
+            return false
+        }
+        if !input.append(sample) {
+            logger.error(
+                "Session recorder sample append failed status=\(Self.describe(writer.status), privacy: .public) error=\(writer.error?.localizedDescription ?? "none", privacy: .public)"
+            )
+            return false
+        }
+        return true
+    }
+
+    private func noteTerminalFailureIfNeeded() {
+        if let writer, writer.status == .failed || writer.status == .cancelled {
+            writerDidFail = true
+        }
+    }
+
+    private func logDropIfNeeded(label: String, count: Int) {
+        if count == 1 || count % 300 == 0 {
+            logger.notice(
+                "Session recorder dropped samples media=\(label, privacy: .public) count=\(count, privacy: .public)"
+            )
+        }
+    }
+
+    // MARK: - Static writer helpers
+
+    private static func makeWriter(
+        outputURL: URL,
+        firstVideo: LongBufferSample,
+        startPTS: Double,
+        includeSystemAudio: Bool,
+        includeMicrophone: Bool
+    ) throws -> LongBufferWriterComponents {
+        let sample = firstVideo.buffer
+        let writer = try AVAssetWriter(outputURL: outputURL, fileType: .mp4)
+        writer.metadata = ClipMetadata.makeMetadataItems()
+        // Flush a moov fragment every second so a recording interrupted by a crash
+        // or hard power-off stays playable up to the last fragment.
+        writer.movieFragmentInterval = CMTime(seconds: 1, preferredTimescale: 600)
+        writer.shouldOptimizeForNetworkUse = true
+
+        guard let formatDescription = sample.formatDescription else {
+            throw SessionRecorderError.cannotAddInput
+        }
+        let videoInput = AVAssetWriterInput(
+            mediaType: .video,
+            outputSettings: nil,
+            sourceFormatHint: formatDescription
+        )
+        videoInput.expectsMediaDataInRealTime = true
+        guard writer.canAdd(videoInput) else {
+            throw SessionRecorderError.cannotAddInput
+        }
+        writer.add(videoInput)
+
+        var systemAudioInput: AVAssetWriterInput?
+        if includeSystemAudio {
+            let input = Self.makeAudioInput()
+            if writer.canAdd(input) {
+                writer.add(input)
+                systemAudioInput = input
+            }
+        }
+
+        var micInput: AVAssetWriterInput?
+        if includeMicrophone {
+            let input = Self.makeAudioInput()
+            if writer.canAdd(input) {
+                writer.add(input)
+                micInput = input
+            }
+        }
+
+        guard writer.startWriting() else {
+            throw writer.error ?? SessionRecorderError.cannotStartWriting
+        }
+        writer.startSession(atSourceTime: CMTime(seconds: startPTS, preferredTimescale: 600))
+
+        return LongBufferWriterComponents(
+            writer: writer,
+            videoInput: videoInput,
+            systemAudioInput: systemAudioInput,
+            micInput: micInput
+        )
+    }
+
+    private static func finishWriter(_ writerBox: LongBufferWriterBox) async throws {
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+            writerBox.writer.finishWriting {
+                if writerBox.writer.status == .completed {
+                    continuation.resume()
+                } else {
+                    continuation.resume(
+                        throwing: writerBox.writer.error ?? SessionRecorderError.finalizeFailed
+                    )
+                }
+            }
+        }
+    }
+
+    private static func makeAudioInput() -> AVAssetWriterInput {
+        let settings: [String: Any] = [
+            AVFormatIDKey: Int(kAudioFormatMPEG4AAC),
+            AVSampleRateKey: 48000,
+            AVNumberOfChannelsKey: 2,
+            AVEncoderBitRateKey: 192000
+        ]
+        let input = AVAssetWriterInput(mediaType: .audio, outputSettings: settings)
+        input.expectsMediaDataInRealTime = true
+        return input
+    }
+
+    private func presentationTimeStamp(_ sample: CMSampleBuffer) -> Double {
+        let pts = CMSampleBufferGetPresentationTimeStamp(sample)
+        return pts.isValid ? pts.seconds : 0
+    }
+
+    /// A sample is a keyframe unless it's explicitly marked not-a-sync-sample.
+    private static func isKeyframe(_ sampleBuffer: CMSampleBuffer) -> Bool {
+        guard let attachments = CMSampleBufferGetSampleAttachmentsArray(sampleBuffer, createIfNecessary: false) as? [[String: Any]],
+              let attachment = attachments.first else {
+            return true
+        }
+        if let notSync = attachment[kCMSampleAttachmentKey_NotSync as String] as? Bool {
+            return !notSync
+        }
+        return true
+    }
+
+    private static func describe(_ status: AVAssetWriter.Status) -> String {
+        switch status {
+        case .unknown: "unknown"
+        case .writing: "writing"
+        case .completed: "completed"
+        case .failed: "failed"
+        case .cancelled: "cancelled"
+        @unknown default: "unrecognized"
+        }
+    }
+}

--- a/Sources/UI/MenuBar/MenuBarState.swift
+++ b/Sources/UI/MenuBar/MenuBarState.swift
@@ -14,16 +14,16 @@ public final class MenuBarState: ObservableObject {
     @Published public private(set) var isSessionRecording = false
     @Published public private(set) var saveStatus: SaveStatus = .idle
     @Published public private(set) var recordingElapsedSeconds: TimeInterval = 0
+    @Published public private(set) var sessionRecordingElapsedSeconds: TimeInterval = 0
     @Published public private(set) var extendedBufferElapsedSeconds: TimeInterval = 0
-    @Published public private(set) var sessionElapsedSeconds: TimeInterval = 0
     @Published public private(set) var bufferedSeconds: TimeInterval = 0
     @Published public private(set) var bufferMemoryBytes: Int = 0
     @Published public private(set) var availableUpdate: AvailableUpdate?
 
     private var saveStatusResetTask: Task<Void, Never>?
     private var recordingStartedAt: Date?
+    private var sessionRecordingStartedAt: Date?
     private var extendedBufferStartedAt: Date?
-    private var sessionStartedAt: Date?
 
     public init() {}
 
@@ -43,15 +43,27 @@ public final class MenuBarState: ObservableObject {
     }
 
     public func updateRecordingElapsed(at date: Date = Date()) {
-        if isRecording, let recordingStartedAt {
-            recordingElapsedSeconds = max(0, date.timeIntervalSince(recordingStartedAt))
+        if isSessionRecording, let sessionRecordingStartedAt {
+            sessionRecordingElapsedSeconds = max(0, date.timeIntervalSince(sessionRecordingStartedAt))
         }
+        guard isRecording, let recordingStartedAt else {
+            return
+        }
+        recordingElapsedSeconds = max(0, date.timeIntervalSince(recordingStartedAt))
         if let extendedBufferStartedAt {
             extendedBufferElapsedSeconds = max(0, date.timeIntervalSince(extendedBufferStartedAt))
         }
-        if isSessionRecording, let sessionStartedAt {
-            sessionElapsedSeconds = max(0, date.timeIntervalSince(sessionStartedAt))
+    }
+
+    public func setSessionRecording(_ isRecording: Bool, at date: Date = Date()) {
+        if isRecording && !isSessionRecording {
+            sessionRecordingStartedAt = date
+            sessionRecordingElapsedSeconds = 0
+        } else if !isRecording {
+            sessionRecordingStartedAt = nil
+            sessionRecordingElapsedSeconds = 0
         }
+        isSessionRecording = isRecording
     }
 
     public func setExtendedBufferRecording(_ isRecording: Bool, at date: Date = Date()) {
@@ -62,17 +74,6 @@ public final class MenuBarState: ObservableObject {
             extendedBufferStartedAt = nil
             extendedBufferElapsedSeconds = 0
         }
-    }
-
-    public func setSessionRecording(_ isRecording: Bool, at date: Date = Date()) {
-        if isRecording && !isSessionRecording {
-            sessionStartedAt = date
-            sessionElapsedSeconds = 0
-        } else if !isRecording {
-            sessionStartedAt = nil
-            sessionElapsedSeconds = 0
-        }
-        isSessionRecording = isRecording
     }
 
     public func setBufferedSeconds(_ bufferedSeconds: TimeInterval) {
@@ -130,11 +131,8 @@ public final class MenuBarState: ObservableObject {
 
     /// Recording time shown to the user, capped at the largest configured
     /// replay window — elapsed time beyond what can still be saved isn't
-    /// actionable. Session recording shows uncapped elapsed time instead.
+    /// actionable.
     public var displayedRecordingSeconds: TimeInterval {
-        if isSessionRecording {
-            return sessionElapsedSeconds
-        }
         let quickCap = TimeInterval(AppSettings.bufferDurationSeconds)
         let cap = AppSettings.longBufferEnabled
             ? max(quickCap, TimeInterval(AppSettings.longBufferDurationSeconds))
@@ -150,8 +148,8 @@ public final class MenuBarState: ObservableObject {
         Self.formattedDuration(extendedBufferElapsedSeconds)
     }
 
-    public var formattedSessionDuration: String {
-        Self.formattedDuration(sessionElapsedSeconds)
+    public var formattedSessionRecordingDuration: String {
+        Self.formattedDuration(sessionRecordingElapsedSeconds)
     }
 
     public static func formattedDuration(_ seconds: TimeInterval) -> String {

--- a/Sources/UI/MenuBar/StatusItemController.swift
+++ b/Sources/UI/MenuBar/StatusItemController.swift
@@ -10,13 +10,13 @@ public final class StatusItemController: NSObject, NSMenuDelegate, @unchecked Se
     private var state = MenuBarState()
     private var saveItem: NSMenuItem?
     private var saveLongBufferItem: NSMenuItem?
-    private var toggleSessionRecordingItem: NSMenuItem?
     private var toggleRecordingItem: NSMenuItem?
+    private var screenRecordingItem: NSMenuItem?
+    private var screenRecordingDurationItem: NSMenuItem?
     private var libraryItem: NSMenuItem?
     private var revealLastClipItem: NSMenuItem?
     private var openLastClipItem: NSMenuItem?
     private var recordingDurationItem: NSMenuItem?
-    private var sessionDurationItem: NSMenuItem?
     private var bufferUsageItem: NSMenuItem?
     private var longBufferUsageItem: NSMenuItem?
     private var hotkeyHintItem: NSMenuItem?
@@ -26,8 +26,8 @@ public final class StatusItemController: NSObject, NSMenuDelegate, @unchecked Se
 
     public var onSaveClip: (() -> Void)?
     public var onSaveLongBuffer: (() -> Void)?
-    public var onToggleSessionRecording: (() -> Void)?
     public var onToggleRecording: (() -> Void)?
+    public var onToggleScreenRecording: (() -> Void)?
     public var onOpenClipLibrary: (() -> Void)?
     public var onOpenSettings: (() -> Void)?
     public var onQuit: (() -> Void)?
@@ -98,10 +98,6 @@ public final class StatusItemController: NSObject, NSMenuDelegate, @unchecked Se
         saveLongBufferItem.target = self
         menu.addItem(saveLongBufferItem)
 
-        let toggleSessionRecordingItem = NSMenuItem(title: "", action: #selector(toggleSessionRecording), keyEquivalent: "")
-        toggleSessionRecordingItem.target = self
-        menu.addItem(toggleSessionRecordingItem)
-
         let hotkeyHintItem = NSMenuItem(title: "No hotkey set — configure in Settings", action: nil, keyEquivalent: "")
         hotkeyHintItem.isEnabled = false
         menu.addItem(hotkeyHintItem)
@@ -109,6 +105,10 @@ public final class StatusItemController: NSObject, NSMenuDelegate, @unchecked Se
         let toggleRecordingItem = NSMenuItem(title: "", action: #selector(toggleRecording), keyEquivalent: "")
         toggleRecordingItem.target = self
         menu.addItem(toggleRecordingItem)
+
+        let screenRecordingItem = NSMenuItem(title: "", action: #selector(toggleScreenRecording), keyEquivalent: "")
+        screenRecordingItem.target = self
+        menu.addItem(screenRecordingItem)
 
         let libraryItem = NSMenuItem(title: "Clip Library", action: #selector(openClipLibrary), keyEquivalent: "")
         libraryItem.target = self
@@ -126,9 +126,9 @@ public final class StatusItemController: NSObject, NSMenuDelegate, @unchecked Se
         recordingDurationItem.isEnabled = false
         menu.addItem(recordingDurationItem)
 
-        let sessionDurationItem = NSMenuItem(title: "", action: nil, keyEquivalent: "")
-        sessionDurationItem.isEnabled = false
-        menu.addItem(sessionDurationItem)
+        let screenRecordingDurationItem = NSMenuItem(title: "", action: nil, keyEquivalent: "")
+        screenRecordingDurationItem.isEnabled = false
+        menu.addItem(screenRecordingDurationItem)
 
         let bufferUsageItem = NSMenuItem(title: "", action: nil, keyEquivalent: "")
         bufferUsageItem.isEnabled = false
@@ -155,13 +155,13 @@ public final class StatusItemController: NSObject, NSMenuDelegate, @unchecked Se
 
         self.saveItem = saveItem
         self.saveLongBufferItem = saveLongBufferItem
-        self.toggleSessionRecordingItem = toggleSessionRecordingItem
         self.toggleRecordingItem = toggleRecordingItem
+        self.screenRecordingItem = screenRecordingItem
+        self.screenRecordingDurationItem = screenRecordingDurationItem
         self.libraryItem = libraryItem
         self.openLastClipItem = openLastClipItem
         self.revealLastClipItem = revealLastClipItem
         self.recordingDurationItem = recordingDurationItem
-        self.sessionDurationItem = sessionDurationItem
         self.bufferUsageItem = bufferUsageItem
         self.longBufferUsageItem = longBufferUsageItem
         self.hotkeyHintItem = hotkeyHintItem
@@ -191,12 +191,14 @@ public final class StatusItemController: NSObject, NSMenuDelegate, @unchecked Se
             saveInProgress: state.isSaveInProgress
         )
 
-        toggleSessionRecordingItem?.title = state.isSessionRecording
-            ? "Stop & Save Session"
-            : "Start Session Recording"
-        toggleSessionRecordingItem?.isEnabled = !state.isSaveInProgress
-
         toggleRecordingItem?.title = state.isRecording ? "Stop Recording" : "Start Recording"
+
+        screenRecordingItem?.title = state.isSessionRecording ? "Stop Screen Recording" : "Start Screen Recording"
+        // No single composite stream in separate-files dual mode, so recording is
+        // unavailable there (mirrors the long buffer).
+        screenRecordingItem?.isHidden = isSeparateDualSaveMode && !state.isSessionRecording
+        screenRecordingDurationItem?.title = "Screen recording: \(state.formattedSessionRecordingDuration)"
+        screenRecordingDurationItem?.isHidden = !state.isSessionRecording
 
         libraryItem?.title = "Clip Library"
 
@@ -210,9 +212,6 @@ public final class StatusItemController: NSObject, NSMenuDelegate, @unchecked Se
 
         recordingDurationItem?.title = "Recording: \(state.formattedRecordingDuration)"
         recordingDurationItem?.isHidden = !state.isRecording
-
-        sessionDurationItem?.title = "Session: \(state.formattedSessionDuration)"
-        sessionDurationItem?.isHidden = !state.isSessionRecording
 
         let quickReplayCap = TimeInterval(replaySeconds)
         let capLabel = MenuBarState.formattedDuration(quickReplayCap)
@@ -251,9 +250,7 @@ public final class StatusItemController: NSObject, NSMenuDelegate, @unchecked Se
     private func updateTooltip() {
         guard let button = statusItem?.button else { return }
 
-        if state.isSessionRecording {
-            button.toolTip = "\(AppBranding.name) — Session \(state.formattedSessionDuration) (stop to save)"
-        } else if state.isRecording {
+        if state.isRecording {
             if AppSettings.longBufferEnabled {
                 let longReplayCap = TimeInterval(AppSettings.longBufferDurationSeconds)
                 let available = min(state.extendedBufferElapsedSeconds, longReplayCap)
@@ -281,12 +278,17 @@ public final class StatusItemController: NSObject, NSMenuDelegate, @unchecked Se
         onSaveLongBuffer?()
     }
 
-    @objc private func toggleSessionRecording() {
-        onToggleSessionRecording?()
-    }
-
     @objc private func toggleRecording() {
         onToggleRecording?()
+    }
+
+    @objc private func toggleScreenRecording() {
+        onToggleScreenRecording?()
+    }
+
+    private var isSeparateDualSaveMode: Bool {
+        AppSettings.captureMode == CaptureMode.dualSideBySide.rawValue
+            && AppSettings.dualCaptureSaveMode == DualCaptureSaveMode.separateFiles.rawValue
     }
 
     @objc private func openSettings() {
@@ -347,7 +349,6 @@ public final class StatusItemController: NSObject, NSMenuDelegate, @unchecked Se
             || KeyboardShortcuts.getShortcut(for: .saveLast15Seconds) != nil
             || KeyboardShortcuts.getShortcut(for: .saveLast60Seconds) != nil
             || KeyboardShortcuts.getShortcut(for: .saveLongBuffer) != nil
-            || KeyboardShortcuts.getShortcut(for: .toggleSessionRecording) != nil
     }
 }
 
@@ -376,11 +377,14 @@ private struct StatusBadgeView: View {
                     .foregroundStyle(AppTheme.danger)
             case .idle:
                 if state.isSessionRecording {
-                    Circle()
+                    // Same footprint as the replay indicator so it can't overflow
+                    // the menu bar differently — a filled red square (vs the
+                    // replay dot) marks a full screen recording.
+                    RoundedRectangle(cornerRadius: 2)
                         .fill(AppTheme.danger)
-                        .frame(width: 8, height: 8)
+                        .frame(width: 9, height: 9)
                         .frame(width: 12, height: 12)
-                    Text("S \(state.formattedSessionDuration)")
+                    Text(state.formattedSessionRecordingDuration)
                         .foregroundStyle(AppTheme.textPrimary)
                 } else if state.isRecording {
                     Circle()
@@ -424,7 +428,7 @@ private struct StatusBadgeView: View {
         case .saving:
             return AppTheme.accent.opacity(0.12)
         case .idle:
-            if state.isSessionRecording || state.isRecording {
+            if state.isRecording {
                 return AppTheme.danger.opacity(0.12)
             }
             return AppTheme.accent.opacity(0.10)

--- a/Sources/UI/Settings/AppSettings.swift
+++ b/Sources/UI/Settings/AppSettings.swift
@@ -166,6 +166,8 @@ public enum AppSettings {
     public static var captureSystemAudio: Bool { Defaults[.captureSystemAudio] }
     public static var captureMicrophone: Bool { Defaults[.captureMicrophone] }
     public static var mergeAudioTracks: Bool { Defaults[.mergeAudioTracks] }
+    public static var sessionRecordingSystemAudio: Bool { Defaults[.sessionRecordingSystemAudio] }
+    public static var sessionRecordingMicrophone: Bool { Defaults[.sessionRecordingMicrophone] }
     public static var playAudioCueOnSave: Bool { Defaults[.playAudioCueOnSave] }
     public static var showNotificationOnSave: Bool { Defaults[.showNotificationOnSave] }
     public static var clipFilenameTemplate: String { Defaults[.clipFilenameTemplate] }
@@ -326,6 +328,13 @@ public extension Defaults.Keys {
     static let excludeOwnAppAudio = Key<Bool>("excludeOwnAppAudio", default: true)
     static let perAppAudioEnabled = Key<Bool>("perAppAudioEnabled", default: false)
     static let perAppAudioBundleID = Key<String>("perAppAudioBundleID", default: "")
+
+    // Screen Recording — the continuous recorder's own audio selection, kept
+    // independent from the replay buffer's captureSystemAudio/captureMicrophone.
+    // Snapshot at recording start (not observed live), so a mid-recording change
+    // applies to the next recording.
+    static let sessionRecordingSystemAudio = Key<Bool>("sessionRecordingSystemAudio", default: true)
+    static let sessionRecordingMicrophone = Key<Bool>("sessionRecordingMicrophone", default: false)
 
     static let memoryCapMB = Key<Double>("memoryCapMB", default: 1536)
     static let queueDepth = Key<Int>("queueDepth", default: 5)

--- a/Sources/UI/Settings/SettingsView+Audio.swift
+++ b/Sources/UI/Settings/SettingsView+Audio.swift
@@ -125,6 +125,17 @@ extension SettingsView {
             }
 
             Section {
+                Toggle("Record system audio", isOn: $sessionRecordingSystemAudio)
+                Toggle("Record microphone", isOn: $sessionRecordingMicrophone)
+
+                Label("Independent audio for start–stop screen recording (start it from the menu bar or a hotkey; video follows the Video tab). These don't affect the replay buffer above. Changing capture or encoding settings while recording stops it — the clip so far is saved.", systemImage: "record.circle")
+                    .foregroundStyle(AppTheme.textSecondary)
+                    .font(.system(size: 12, design: .rounded))
+            } header: {
+                sectionHeader(icon: "record.circle", title: "Screen Recording")
+            }
+
+            Section {
                 Label("Audio source changes apply automatically.", systemImage: "bolt.circle")
                     .foregroundStyle(AppTheme.textSecondary)
                     .font(.system(size: 12, design: .rounded))

--- a/Sources/UI/Settings/SettingsView+Hotkeys.swift
+++ b/Sources/UI/Settings/SettingsView+Hotkeys.swift
@@ -8,6 +8,7 @@ extension SettingsView {
             Section {
                 KeyboardShortcuts.Recorder("Save clip", name: .saveClip)
                 KeyboardShortcuts.Recorder("Start/stop recording", name: .toggleRecording)
+                KeyboardShortcuts.Recorder("Start/stop screen recording", name: .toggleScreenRecording)
             } header: {
                 sectionHeader(icon: "bolt.fill", title: "Primary")
             }
@@ -18,18 +19,6 @@ extension SettingsView {
                 KeyboardShortcuts.Recorder("Save extended replay", name: .saveLongBuffer)
             } header: {
                 sectionHeader(icon: "stopwatch", title: "Quick Presets")
-            }
-
-            Section {
-                KeyboardShortcuts.Recorder("Start/stop session recording", name: .toggleSessionRecording)
-                Label(
-                    "Records until you stop, then saves one file with screen, system audio, and mic. Separate from the instant-replay buffer.",
-                    systemImage: "info.circle"
-                )
-                .foregroundStyle(AppTheme.textSecondary)
-                .font(.system(size: 12, design: .rounded))
-            } header: {
-                sectionHeader(icon: "record.circle", title: "Session Recording")
             }
 
             Section {

--- a/Sources/UI/Settings/SettingsView+Video.swift
+++ b/Sources/UI/Settings/SettingsView+Video.swift
@@ -146,17 +146,6 @@ extension SettingsView {
             } header: {
                 sectionHeader(icon: "clock.badge.exclamationmark", title: "Long Buffer")
             }
-
-            Section {
-                Toggle("Record system audio", isOn: $sessionRecordingSystemAudio)
-                Toggle("Record microphone", isOn: $sessionRecordingMicrophone)
-
-                Label("Screen recording saves a whole session to one file, using the video settings above. Its audio is independent of the replay buffer. Changing capture or encoding settings while recording stops it — the clip up to that point is saved.", systemImage: "record.circle")
-                    .foregroundStyle(AppTheme.textSecondary)
-                    .font(.system(size: 12, design: .rounded))
-            } header: {
-                sectionHeader(icon: "record.circle", title: "Screen Recording")
-            }
         }
         .formStyle(.grouped)
     }

--- a/Sources/UI/Settings/SettingsView+Video.swift
+++ b/Sources/UI/Settings/SettingsView+Video.swift
@@ -148,14 +148,14 @@ extension SettingsView {
             }
 
             Section {
-                Label(
-                    "Session recording is always available from the menu bar (Start Session Recording) or a hotkey in Settings → Hotkeys. It records until you stop, then saves one MP4 with screen, system audio, and microphone — no rolling buffer cutoff.",
-                    systemImage: "record.circle"
-                )
-                .foregroundStyle(AppTheme.textSecondary)
-                .font(.system(size: 12, design: .rounded))
+                Toggle("Record system audio", isOn: $sessionRecordingSystemAudio)
+                Toggle("Record microphone", isOn: $sessionRecordingMicrophone)
+
+                Label("Screen recording saves a whole session to one file, using the video settings above. Its audio is independent of the replay buffer. Changing capture or encoding settings while recording stops it — the clip up to that point is saved.", systemImage: "record.circle")
+                    .foregroundStyle(AppTheme.textSecondary)
+                    .font(.system(size: 12, design: .rounded))
             } header: {
-                sectionHeader(icon: "record.circle", title: "Session Recording")
+                sectionHeader(icon: "record.circle", title: "Screen Recording")
             }
         }
         .formStyle(.grouped)

--- a/Sources/UI/Settings/SettingsView.swift
+++ b/Sources/UI/Settings/SettingsView.swift
@@ -37,6 +37,8 @@ public struct SettingsView: View {
     @Default(.perAppAudioBundleID) var perAppAudioBundleID
     @Default(.systemAudioVolume) var systemAudioVolume
     @Default(.microphoneVolume) var microphoneVolume
+    @Default(.sessionRecordingSystemAudio) var sessionRecordingSystemAudio
+    @Default(.sessionRecordingMicrophone) var sessionRecordingMicrophone
 
     @Default(.memoryCapMB) var memoryCapMB
     @Default(.queueDepth) var queueDepth

--- a/Tests/SavePipelineTests/LongBufferRecorderTests.swift
+++ b/Tests/SavePipelineTests/LongBufferRecorderTests.swift
@@ -163,7 +163,7 @@ final class LongBufferRecorderTests: XCTestCase {
 
         let gate = ExportGate()
         let observation = ExportObservation()
-        let recorder = makeFileBackedRecorder { segments, _, outputDirectory, _, _, _ in
+        let recorder = makeFileBackedRecorder { segments, _, outputDirectory, _, _ in
             await observation.record(segments.map(\.url))
             await gate.pauseExporter()
             let outputURL = outputDirectory.appendingPathComponent("SuccessfulExport.mp4")
@@ -241,7 +241,7 @@ final class LongBufferRecorderTests: XCTestCase {
         let gate = ExportGate()
         let observation = ExportObservation()
         let attempts = ExportAttemptTracker()
-        let recorder = makeFileBackedRecorder { segments, _, outputDirectory, _, _, _ in
+        let recorder = makeFileBackedRecorder { segments, _, outputDirectory, _, _ in
             await observation.record(segments.map(\.url))
             if await attempts.next() == 1 {
                 await gate.pauseExporter()
@@ -317,7 +317,7 @@ final class LongBufferRecorderTests: XCTestCase {
         defer { try? FileManager.default.removeItem(at: outputDirectory) }
 
         let signal = StartSignal()
-        let recorder = makeFileBackedRecorder { _, _, _, _, _, _ in
+        let recorder = makeFileBackedRecorder { _, _, _, _, _ in
             await signal.markStarted()
             try await Task.sleep(for: .seconds(60))
             throw TestError.simulatedExportFailure
@@ -360,41 +360,6 @@ final class LongBufferRecorderTests: XCTestCase {
         )
     }
 
-    func testSessionStorageUsesSeparateDirectoryAndKeepsFullDuration() async throws {
-        let outputDirectory = FileManager.default.temporaryDirectory
-            .appendingPathComponent(UUID().uuidString, isDirectory: true)
-        defer { try? FileManager.default.removeItem(at: outputDirectory) }
-
-        let recorder = makeFileBackedRecorder { segments, lastSeconds, outputDirectory, _, _, suffix in
-            XCTAssertEqual(suffix, "Session")
-            XCTAssertGreaterThanOrEqual(lastSeconds, 100)
-            XCTAssertFalse(segments.isEmpty)
-            let url = outputDirectory.appendingPathComponent("session-out.mp4")
-            try Data("session".utf8).write(to: url)
-            return url
-        }
-
-        await recorder.configure(
-            enabled: true,
-            maxDurationSeconds: .infinity,
-            outputDirectory: outputDirectory,
-            storage: .session
-        )
-
-        let early = try makeVideoSample(pts: 1)
-        let late = try makeVideoSample(pts: 120)
-        await recorder.appendVideo(early)
-        await recorder.appendVideo(late)
-
-        let saved = try await recorder.saveEntireRecording(outputDirectory: outputDirectory)
-        XCTAssertEqual(saved.lastPathComponent, "session-out.mp4")
-
-        let sessionDir = outputDirectory.appendingPathComponent(".ReplayCapSession", isDirectory: true)
-        XCTAssertTrue(FileManager.default.fileExists(atPath: sessionDir.path))
-        let longBufferDir = outputDirectory.appendingPathComponent(".ReplayCapLongBuffer", isDirectory: true)
-        XCTAssertFalse(FileManager.default.fileExists(atPath: longBufferDir.path))
-    }
-
     func testConfigureRemovesOnlyOrphanedLegacyReplayMacSegments() async throws {
         let outputDirectory = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString, isDirectory: true)
@@ -411,7 +376,7 @@ final class LongBufferRecorderTests: XCTestCase {
         try Data("user file".utf8).write(to: unrelated)
         try FileManager.default.createDirectory(at: similarlyNamedDirectory, withIntermediateDirectories: true)
 
-        let recorder = makeFileBackedRecorder { _, _, outputDirectory, _, _, _ in
+        let recorder = makeFileBackedRecorder { _, _, outputDirectory, _, _ in
             outputDirectory.appendingPathComponent("unused.mp4")
         }
         await recorder.configure(

--- a/Tests/SavePipelineTests/SessionRecorderTests.swift
+++ b/Tests/SavePipelineTests/SessionRecorderTests.swift
@@ -1,0 +1,257 @@
+import XCTest
+import AVFoundation
+import CoreMedia
+import CoreVideo
+@testable import Save
+
+final class SessionRecorderTests: XCTestCase {
+    private enum TestError: Error {
+        case simulatedFinishFailure
+        case couldNotCreatePixelBuffer(OSStatus)
+        case couldNotCreateSampleBuffer(OSStatus)
+    }
+
+    /// Thread-safe capture of what the injected (synchronous) writer builder saw.
+    private final class BuildObserver: @unchecked Sendable {
+        private let lock = NSLock()
+        private var _buildCount = 0
+        private var _includeSystemAudio: [Bool] = []
+        private var _includeMicrophone: [Bool] = []
+        private var _urls: [URL] = []
+
+        func record(url: URL, includeSystemAudio: Bool, includeMicrophone: Bool) {
+            lock.lock(); defer { lock.unlock() }
+            _buildCount += 1
+            _includeSystemAudio.append(includeSystemAudio)
+            _includeMicrophone.append(includeMicrophone)
+            _urls.append(url)
+        }
+
+        var buildCount: Int { lock.lock(); defer { lock.unlock() }; return _buildCount }
+        var includeSystemAudio: [Bool] { lock.lock(); defer { lock.unlock() }; return _includeSystemAudio }
+        var includeMicrophone: [Bool] { lock.lock(); defer { lock.unlock() }; return _includeMicrophone }
+        var urls: [URL] { lock.lock(); defer { lock.unlock() }; return _urls }
+    }
+
+    // MARK: - Tests
+
+    func testStopBeforeFirstFrameReturnsNilAndBuildsNoWriter() async throws {
+        let outputDirectory = makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: outputDirectory) }
+
+        let observer = BuildObserver()
+        let recorder = makeRecorder(observer: observer)
+
+        await recorder.start(
+            outputDirectory: outputDirectory,
+            recordSystemAudio: true,
+            recordMicrophone: false,
+            baseName: nil
+        )
+        let url = await recorder.stop()
+
+        XCTAssertNil(url)
+        XCTAssertEqual(observer.buildCount, 0, "No video frame arrived, so no writer should be built")
+    }
+
+    func testWriterBuiltOnceAcrossManyFrames() async throws {
+        let outputDirectory = makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: outputDirectory) }
+
+        let observer = BuildObserver()
+        let recorder = makeRecorder(observer: observer)
+
+        await recorder.start(
+            outputDirectory: outputDirectory,
+            recordSystemAudio: false,
+            recordMicrophone: false,
+            baseName: nil
+        )
+        for index in 0..<5 {
+            await recorder.appendVideo(try makeVideoSample(pts: Double(index) / 30.0))
+        }
+        _ = await recorder.stop()
+
+        XCTAssertEqual(observer.buildCount, 1, "The single-file writer must be built exactly once")
+    }
+
+    func testStartPassesAudioSelectionToBuilder() async throws {
+        let outputDirectory = makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: outputDirectory) }
+
+        let observer = BuildObserver()
+        let recorder = makeRecorder(observer: observer)
+
+        await recorder.start(
+            outputDirectory: outputDirectory,
+            recordSystemAudio: true,
+            recordMicrophone: true,
+            baseName: nil
+        )
+        await recorder.appendVideo(try makeVideoSample())
+        _ = await recorder.stop()
+
+        XCTAssertEqual(observer.includeSystemAudio, [true])
+        XCTAssertEqual(observer.includeMicrophone, [true])
+    }
+
+    func testAppendAfterStopDoesNotBuildSecondWriter() async throws {
+        let outputDirectory = makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: outputDirectory) }
+
+        let observer = BuildObserver()
+        let recorder = makeRecorder(observer: observer)
+
+        await recorder.start(
+            outputDirectory: outputDirectory,
+            recordSystemAudio: false,
+            recordMicrophone: false,
+            baseName: nil
+        )
+        await recorder.appendVideo(try makeVideoSample(pts: 0))
+        _ = await recorder.stop()
+        // A late-draining frame after stop must not spawn a second file.
+        await recorder.appendVideo(try makeVideoSample(pts: 1))
+
+        XCTAssertEqual(observer.buildCount, 1)
+        let recording = await recorder.isRecording
+        XCTAssertFalse(recording)
+    }
+
+    func testStopReturnsURLAndPostsNotificationOnSuccess() async throws {
+        let outputDirectory = makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: outputDirectory) }
+
+        let recorder = SessionRecorder(
+            writerBuilder: { url, _, _, _, _ in
+                try Data("recording".utf8).write(to: url)
+                return try Self.stubComponents(url: url)
+            },
+            writerFinisher: { _ in }
+        )
+
+        let notified = expectation(forNotification: .replayCapClipSaved, object: nil, handler: nil)
+
+        await recorder.start(
+            outputDirectory: outputDirectory,
+            recordSystemAudio: false,
+            recordMicrophone: false,
+            baseName: nil
+        )
+        await recorder.appendVideo(try makeVideoSample())
+        let url = await recorder.stop()
+
+        await fulfillment(of: [notified], timeout: 2.0)
+        let unwrapped = try XCTUnwrap(url)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: unwrapped.path))
+        XCTAssertEqual(unwrapped.pathExtension, "mp4")
+        XCTAssertTrue(unwrapped.lastPathComponent.contains("Recording"))
+    }
+
+    func testFinishFailureRemovesPartialFileAndReturnsNil() async throws {
+        let outputDirectory = makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: outputDirectory) }
+
+        let urlBox = URLBox()
+        let recorder = SessionRecorder(
+            writerBuilder: { url, _, _, _, _ in
+                try Data("partial".utf8).write(to: url)
+                urlBox.set(url)
+                return try Self.stubComponents(url: url)
+            },
+            writerFinisher: { _ in throw TestError.simulatedFinishFailure }
+        )
+
+        await recorder.start(
+            outputDirectory: outputDirectory,
+            recordSystemAudio: false,
+            recordMicrophone: false,
+            baseName: nil
+        )
+        await recorder.appendVideo(try makeVideoSample())
+        let url = await recorder.stop()
+
+        XCTAssertNil(url)
+        let partial = try XCTUnwrap(urlBox.value)
+        XCTAssertFalse(
+            FileManager.default.fileExists(atPath: partial.path),
+            "A failed finalize must remove the partial file"
+        )
+    }
+
+    // MARK: - Helpers
+
+    private final class URLBox: @unchecked Sendable {
+        private let lock = NSLock()
+        private var _value: URL?
+        func set(_ url: URL) { lock.lock(); _value = url; lock.unlock() }
+        var value: URL? { lock.lock(); defer { lock.unlock() }; return _value }
+    }
+
+    private func makeRecorder(observer: BuildObserver) -> SessionRecorder {
+        SessionRecorder(
+            writerBuilder: { url, _, _, sys, mic in
+                observer.record(url: url, includeSystemAudio: sys, includeMicrophone: mic)
+                return try Self.stubComponents(url: url)
+            },
+            writerFinisher: { _ in }
+        )
+    }
+
+    private func makeTempDirectory() -> URL {
+        FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+    }
+
+    private static func stubComponents(url: URL) throws -> LongBufferWriterComponents {
+        let writer = try AVAssetWriter(outputURL: url, fileType: .mp4)
+        return LongBufferWriterComponents(
+            writer: writer,
+            videoInput: nil,
+            systemAudioInput: nil,
+            micInput: nil
+        )
+    }
+
+    private func makeVideoSample(pts: Double = 1.0 / 30.0) throws -> LongBufferSample {
+        var pixelBuffer: CVPixelBuffer?
+        let pixelStatus = CVPixelBufferCreate(
+            kCFAllocatorDefault,
+            64,
+            64,
+            kCVPixelFormatType_32BGRA,
+            [kCVPixelBufferIOSurfacePropertiesKey: [:]] as CFDictionary,
+            &pixelBuffer
+        )
+        guard pixelStatus == kCVReturnSuccess, let pixelBuffer else {
+            throw TestError.couldNotCreatePixelBuffer(pixelStatus)
+        }
+
+        var formatDescription: CMVideoFormatDescription?
+        let formatStatus = CMVideoFormatDescriptionCreateForImageBuffer(
+            allocator: kCFAllocatorDefault,
+            imageBuffer: pixelBuffer,
+            formatDescriptionOut: &formatDescription
+        )
+        guard formatStatus == noErr, let formatDescription else {
+            throw TestError.couldNotCreateSampleBuffer(formatStatus)
+        }
+
+        var timing = CMSampleTimingInfo(
+            duration: CMTime(value: 1, timescale: 30),
+            presentationTimeStamp: CMTime(seconds: pts, preferredTimescale: 600),
+            decodeTimeStamp: .invalid
+        )
+        var sampleBuffer: CMSampleBuffer?
+        let sampleStatus = CMSampleBufferCreateReadyWithImageBuffer(
+            allocator: kCFAllocatorDefault,
+            imageBuffer: pixelBuffer,
+            formatDescription: formatDescription,
+            sampleTiming: &timing,
+            sampleBufferOut: &sampleBuffer
+        )
+        guard sampleStatus == noErr, let sampleBuffer else {
+            throw TestError.couldNotCreateSampleBuffer(sampleStatus)
+        }
+        return LongBufferSample(sampleBuffer)
+    }
+}

--- a/Tests/UITests/MenuBarStateTests.swift
+++ b/Tests/UITests/MenuBarStateTests.swift
@@ -75,33 +75,4 @@ final class MenuBarStateTests: XCTestCase {
         XCTAssertEqual(state.extendedBufferElapsedSeconds, 45)
         XCTAssertEqual(state.formattedExtendedBufferDuration, "00:45")
     }
-
-    func testSessionRecordingShowsUncappedElapsedTime() {
-        Defaults[.bufferDurationSeconds] = 30
-        Defaults[.longBufferEnabled] = false
-        let state = MenuBarState()
-        let start = Date(timeIntervalSinceReferenceDate: 1_000)
-
-        state.setRecording(true, at: start)
-        state.setSessionRecording(true, at: start)
-        state.updateRecordingElapsed(at: start.addingTimeInterval(95))
-
-        XCTAssertTrue(state.isSessionRecording)
-        XCTAssertEqual(state.sessionElapsedSeconds, 95)
-        XCTAssertEqual(state.formattedSessionDuration, "01:35")
-        XCTAssertEqual(state.formattedRecordingDuration, "01:35")
-    }
-
-    func testStoppingSessionRecordingResetsElapsedTime() {
-        let state = MenuBarState()
-        let start = Date(timeIntervalSinceReferenceDate: 1_000)
-
-        state.setSessionRecording(true, at: start)
-        state.updateRecordingElapsed(at: start.addingTimeInterval(45))
-        state.setSessionRecording(false)
-
-        XCTAssertFalse(state.isSessionRecording)
-        XCTAssertEqual(state.sessionElapsedSeconds, 0)
-        XCTAssertEqual(state.formattedSessionDuration, "00:00")
-    }
 }


### PR DESCRIPTION
✨ Added — Screen Recording feature (new)

A continuous start→stop screen recorder, separate from the instant-replay buffer:
- SessionRecorder — taps the already-encoded video stream (no re-encode) and raw PCM audio (AAC-encoded at write); writes one continuous MP4 with instant finalize.
- SessionAppendPump — decouples the real-time capture callbacks from the writer with bounded, drop-oldest backpressure.
- Hotkey to toggle recording + menu-bar item ("Start/Stop Screen Recording") with a distinct badge (red square + timer, vs the replay dot).
- Independent audio toggles — "record system audio" / "record microphone", any combination, that don't leak into replay clips (union capture + per-consumer gating). (Now in the Audio tab.)
- Matches every Video-section setting automatically — display, capture mode, resolution/Retina, frame rate, bitrate, codec, quality preset — since it taps the same encoded stream.
- Runs alongside the replay buffer; auto-starts/stops capture if the buffer is idle, and stops the pipeline it started.
- Saved clips land in the clip library tagged Recording, with the save flash (spinner → green) like replay saves.
- Disk-space preflight before start + low-disk auto-stop during.
- Save-on-quit — finalizes an in-progress recording be
- Blocked in dual "separate files" mode (mirrors the long buffer), with a notification.
- Unit tests (SessionRecorderTests).

🎨 Fixed — desaturated clips (color)

Applies to both replay clips and recordings:
- Capture pinned to sRGB at all 6 SCStreamConfiguration sites (incl. the runtime-update paths, so live fps/bitrate/resolution changes
keep it).
- Encoder tags BT.709 primaries/transfer/matrix (HEVC
- Compositor uses an explicit sRGB working space (dual mode).

🐛 Fixed — bugs in the recording feature

- Black screen at recording start → open the file on aediately when recording begins.
- Menu-bar icon vanishing → badge now matches the repl(no wide "REC" text pushing it off/behind the notch).
- No save flash → finalize now runs the same Saving→Sa
- Orphaned pipeline on a mid-recording settings change → the reshape path stops an owned pipeline instead of leaving it running.
- Orphaned pipeline on rapid start→stop → start/stop a't interleave; rollback stops a pipeline it started.
- Duplicate low-disk finalize → in-flight finalize guard.
- Lost keyframe request → forceNextKeyframe() is consumed only once the frame is actually submitted.
- Silent writer failure → now notifies you instead of dropping the clip quietly.
- Silent replay-buffer reset → warns when adding systepture.

⚡ Efficiency

- Biggest: the extended-replay pump no longer spins ~1hen that feature is off (the default) — it's gated now.
- One buffer wrap per frame, created only when a consu
- Dropped a dead per-frame PTS calc in the recorder.
- Moved the compositor's debug print out of its lock.
- (Deferred two marginal/riskier micro-opts: the raw-CoreFoundation attachment rewrite and swapping the pump lock for atomics.)